### PR TITLE
remove footnotes from publication stanzas

### DIFF
--- a/stanzas/gene-publication/templates/stanza.html.hbs
+++ b/stanzas/gene-publication/templates/stanza.html.hbs
@@ -2,11 +2,5 @@
   <div class="alert alert-danger">{{message}}</div>
 {{else}}
   <table id="dataTable" style="width:100%">
-    {{#if result}}
-      <caption>
-        Note: The link to LitVar leads to a list of all PubMed articles related to this variant.
-        Please find a PMID of your choice in the list.
-      </caption>
-    {{/if}}
   </table>
 {{/with}}

--- a/stanzas/variant-publication/templates/stanza.html.hbs
+++ b/stanzas/variant-publication/templates/stanza.html.hbs
@@ -2,11 +2,5 @@
   <div class="alert alert-danger">{{message}}</div>
 {{else}}
   <table id="dataTable" style="width:100%">
-    {{#if result}}
-      <caption>
-        Note: The link to LitVar leads to a list of all PubMed articles related to this variant.
-        Please find a PMID of your choice in the list.
-      </caption>
-    {{/if}}
   </table>
 {{/with}}


### PR DESCRIPTION
バリアント、遺伝子ビューの文献スタンザの脚注を削除しました。レビューとマージをお願いします。