### PR TITLE
fix frequency-value

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,917 +4,917 @@ export const DATASETS = [
     "layer1": "Japanese",
     "layer2": "",
     "layer3": "",
-    "source": "gem_j_wga"
+    "value": "gem_j_wga"
   },
   {
     "dataset": () => "JGA-NGS",
     "layer1": "Japanese",
     "layer2": "",
     "layer3": "",
-    "source": "jga_ngs"
+    "value": "jga_ngs"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Total",
     "layer2": "",
     "layer3": "",
-    "source": "jga_snp"
+    "value": "jga_snp"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Lung cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno1"
+    "value": "bbj_riken.mpheno1"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Lung cancer",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno1.male"
+    "value": "bbj_riken.mpheno1.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Lung cancer",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno1.female"
+    "value": "bbj_riken.mpheno1.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Esophageal cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno2"
+    "value": "bbj_riken.mpheno2"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Esophageal cancer",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno2.male"
+    "value": "bbj_riken.mpheno2.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Esophageal cancer",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno2.female"
+    "value": "bbj_riken.mpheno2.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Gastric cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno3"
+    "value": "bbj_riken.mpheno3"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Gastric cancer",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno3.male"
+    "value": "bbj_riken.mpheno3.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Gastric cancer",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno3.female"
+    "value": "bbj_riken.mpheno3.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Colorectal cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno4"
+    "value": "bbj_riken.mpheno4"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Colorectal cancer",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno4.male"
+    "value": "bbj_riken.mpheno4.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Colorectal cancer",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno4.female"
+    "value": "bbj_riken.mpheno4.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Liver cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno5"
+    "value": "bbj_riken.mpheno5"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Liver cancer",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno5.male"
+    "value": "bbj_riken.mpheno5.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Liver cancer",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno5.female"
+    "value": "bbj_riken.mpheno5.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Pancreas cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno6"
+    "value": "bbj_riken.mpheno6"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Pancreas cancer",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno6.male"
+    "value": "bbj_riken.mpheno6.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Pancreas cancer",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno6.female"
+    "value": "bbj_riken.mpheno6.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Gallbladder/Cholangiocarcinoma",
     "layer3": "",
-    "source": "bbj_riken.mpheno7"
+    "value": "bbj_riken.mpheno7"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Gallbladder/Cholangiocarcinoma",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno7.male"
+    "value": "bbj_riken.mpheno7.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Gallbladder/Cholangiocarcinoma",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno7.female"
+    "value": "bbj_riken.mpheno7.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Prostate cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno8"
+    "value": "bbj_riken.mpheno8"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Prostate cancer",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno8.male"
+    "value": "bbj_riken.mpheno8.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Breast cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno9"
+    "value": "bbj_riken.mpheno9"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Breast cancer",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno9.female"
+    "value": "bbj_riken.mpheno9.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Cervical cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno10"
+    "value": "bbj_riken.mpheno10"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Cervical cancer",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno10.female"
+    "value": "bbj_riken.mpheno10.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Uterine cancer",
     "layer3": "",
-    "source": "bbj_riken.mpheno11"
+    "value": "bbj_riken.mpheno11"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Uterine cancer",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno11.female"
+    "value": "bbj_riken.mpheno11.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Ovarian center",
     "layer3": "",
-    "source": "bbj_riken.mpheno12"
+    "value": "bbj_riken.mpheno12"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Ovarian center",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno12.female"
+    "value": "bbj_riken.mpheno12.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Hematopoietic tumor",
     "layer3": "",
-    "source": "bbj_riken.mpheno13"
+    "value": "bbj_riken.mpheno13"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Hematopoietic tumor",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno13.male"
+    "value": "bbj_riken.mpheno13.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Neoplasms",
     "layer2": "Hematopoietic tumor",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno13.female"
+    "value": "bbj_riken.mpheno13.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the nervous system",
     "layer2": "Cerebral infarction",
     "layer3": "",
-    "source": "bbj_riken.mpheno14"
+    "value": "bbj_riken.mpheno14"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the nervous system",
     "layer2": "Cerebral infarction",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno14.male"
+    "value": "bbj_riken.mpheno14.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the nervous system",
     "layer2": "Cerebral infarction",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno14.female"
+    "value": "bbj_riken.mpheno14.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the nervous system",
     "layer2": "Cerebral aneurysm",
     "layer3": "",
-    "source": "bbj_riken.mpheno15"
+    "value": "bbj_riken.mpheno15"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the nervous system",
     "layer2": "Cerebral aneurysm",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno15.male"
+    "value": "bbj_riken.mpheno15.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the nervous system",
     "layer2": "Cerebral aneurysm",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno15.female"
+    "value": "bbj_riken.mpheno15.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the nervous system",
     "layer2": "Epilepsy",
     "layer3": "",
-    "source": "bbj_riken.mpheno16"
+    "value": "bbj_riken.mpheno16"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the nervous system",
     "layer2": "Epilepsy",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno16.male"
+    "value": "bbj_riken.mpheno16.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the nervous system",
     "layer2": "Epilepsy",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno16.female"
+    "value": "bbj_riken.mpheno16.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Bronchial asthma",
     "layer3": "",
-    "source": "bbj_riken.mpheno17"
+    "value": "bbj_riken.mpheno17"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Bronchial asthma",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno17.male"
+    "value": "bbj_riken.mpheno17.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Bronchial asthma",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno17.female"
+    "value": "bbj_riken.mpheno17.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Pulmonary tuberculosis",
     "layer3": "",
-    "source": "bbj_riken.mpheno18"
+    "value": "bbj_riken.mpheno18"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Pulmonary tuberculosis",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno18.male"
+    "value": "bbj_riken.mpheno18.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Pulmonary tuberculosis",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno18.female"
+    "value": "bbj_riken.mpheno18.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Chronic obstructive pulmonary disease",
     "layer3": "",
-    "source": "bbj_riken.mpheno19"
+    "value": "bbj_riken.mpheno19"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Chronic obstructive pulmonary disease",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno19.male"
+    "value": "bbj_riken.mpheno19.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Chronic obstructive pulmonary disease",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno19.female"
+    "value": "bbj_riken.mpheno19.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Interstitial lung disease/Pulmonary fibrosis",
     "layer3": "",
-    "source": "bbj_riken.mpheno20"
+    "value": "bbj_riken.mpheno20"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Interstitial lung disease/Pulmonary fibrosis",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno20.male"
+    "value": "bbj_riken.mpheno20.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the respiratory system",
     "layer2": "Interstitial lung disease/Pulmonary fibrosis",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno20.female"
+    "value": "bbj_riken.mpheno20.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Myocardial infarction",
     "layer3": "",
-    "source": "bbj_riken.mpheno21"
+    "value": "bbj_riken.mpheno21"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Myocardial infarction",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno21.male"
+    "value": "bbj_riken.mpheno21.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Myocardial infarction",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno21.female"
+    "value": "bbj_riken.mpheno21.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Unstable angina",
     "layer3": "",
-    "source": "bbj_riken.mpheno22"
+    "value": "bbj_riken.mpheno22"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Unstable angina",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno22.male"
+    "value": "bbj_riken.mpheno22.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Unstable angina",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno22.female"
+    "value": "bbj_riken.mpheno22.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Stable angina",
     "layer3": "",
-    "source": "bbj_riken.mpheno23"
+    "value": "bbj_riken.mpheno23"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Stable angina",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno23.male"
+    "value": "bbj_riken.mpheno23.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Stable angina",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno23.female"
+    "value": "bbj_riken.mpheno23.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Arrhythmia",
     "layer3": "",
-    "source": "bbj_riken.mpheno24"
+    "value": "bbj_riken.mpheno24"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Arrhythmia",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno24.male"
+    "value": "bbj_riken.mpheno24.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Arrhythmia",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno24.female"
+    "value": "bbj_riken.mpheno24.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Heart failure",
     "layer3": "",
-    "source": "bbj_riken.mpheno25"
+    "value": "bbj_riken.mpheno25"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Heart failure",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno25.male"
+    "value": "bbj_riken.mpheno25.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Heart failure",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno25.female"
+    "value": "bbj_riken.mpheno25.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Peripheral arterial diseases",
     "layer3": "",
-    "source": "bbj_riken.mpheno26"
+    "value": "bbj_riken.mpheno26"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Peripheral arterial diseases",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno26.male"
+    "value": "bbj_riken.mpheno26.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the circulatory system",
     "layer2": "Peripheral arterial diseases",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno26.female"
+    "value": "bbj_riken.mpheno26.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Hepato-Biliary-Pancreatic diseases",
     "layer2": "Chronic hepatitis B",
     "layer3": "",
-    "source": "bbj_riken.mpheno27"
+    "value": "bbj_riken.mpheno27"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Hepato-Biliary-Pancreatic diseases",
     "layer2": "Chronic hepatitis B",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno27.male"
+    "value": "bbj_riken.mpheno27.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Hepato-Biliary-Pancreatic diseases",
     "layer2": "Chronic hepatitis B",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno27.female"
+    "value": "bbj_riken.mpheno27.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Hepato-Biliary-Pancreatic diseases",
     "layer2": "Chronic hepatitis C",
     "layer3": "",
-    "source": "bbj_riken.mpheno28"
+    "value": "bbj_riken.mpheno28"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Hepato-Biliary-Pancreatic diseases",
     "layer2": "Chronic hepatitis C",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno28.male"
+    "value": "bbj_riken.mpheno28.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Hepato-Biliary-Pancreatic diseases",
     "layer2": "Chronic hepatitis C",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno28.female"
+    "value": "bbj_riken.mpheno28.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Hepato-Biliary-Pancreatic diseases",
     "layer2": "Liver cirrhosis",
     "layer3": "",
-    "source": "bbj_riken.mpheno29"
+    "value": "bbj_riken.mpheno29"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Hepato-Biliary-Pancreatic diseases",
     "layer2": "Liver cirrhosis",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno29.male"
+    "value": "bbj_riken.mpheno29.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Hepato-Biliary-Pancreatic diseases",
     "layer2": "Liver cirrhosis",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno29.female"
+    "value": "bbj_riken.mpheno29.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the genitourinary system",
     "layer2": "Nephrotic syndrome",
     "layer3": "",
-    "source": "bbj_riken.mpheno30"
+    "value": "bbj_riken.mpheno30"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the genitourinary system",
     "layer2": "Nephrotic syndrome",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno30.male"
+    "value": "bbj_riken.mpheno30.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the genitourinary system",
     "layer2": "Nephrotic syndrome",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno30.female"
+    "value": "bbj_riken.mpheno30.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the genitourinary system",
     "layer2": "Urolithiasis",
     "layer3": "",
-    "source": "bbj_riken.mpheno31"
+    "value": "bbj_riken.mpheno31"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the genitourinary system",
     "layer2": "Urolithiasis",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno31.male"
+    "value": "bbj_riken.mpheno31.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the genitourinary system",
     "layer2": "Urolithiasis",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno31.female"
+    "value": "bbj_riken.mpheno31.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Metabolic diseases",
     "layer2": "Osteoporosis",
     "layer3": "",
-    "source": "bbj_riken.mpheno32"
+    "value": "bbj_riken.mpheno32"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Metabolic diseases",
     "layer2": "Osteoporosis",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno32.male"
+    "value": "bbj_riken.mpheno32.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Metabolic diseases",
     "layer2": "Osteoporosis",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno32.female"
+    "value": "bbj_riken.mpheno32.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Metabolic diseases",
     "layer2": "Diabetes mellitus",
     "layer3": "",
-    "source": "bbj_riken.mpheno33"
+    "value": "bbj_riken.mpheno33"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Metabolic diseases",
     "layer2": "Diabetes mellitus",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno33.male"
+    "value": "bbj_riken.mpheno33.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Metabolic diseases",
     "layer2": "Diabetes mellitus",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno33.female"
+    "value": "bbj_riken.mpheno33.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Metabolic diseases",
     "layer2": "Dyslipidemia",
     "layer3": "",
-    "source": "bbj_riken.mpheno34"
+    "value": "bbj_riken.mpheno34"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Metabolic diseases",
     "layer2": "Dyslipidemia",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno34.male"
+    "value": "bbj_riken.mpheno34.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Metabolic diseases",
     "layer2": "Dyslipidemia",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno34.female"
+    "value": "bbj_riken.mpheno34.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Endocrine diseases",
     "layer2": "Graves' disease",
     "layer3": "",
-    "source": "bbj_riken.mpheno35"
+    "value": "bbj_riken.mpheno35"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Endocrine diseases",
     "layer2": "Graves' disease",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno35.male"
+    "value": "bbj_riken.mpheno35.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Endocrine diseases",
     "layer2": "Graves' disease",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno35.female"
+    "value": "bbj_riken.mpheno35.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Collagen diseases (connective tissue diseases)",
     "layer2": "Rheumatoid arthritis",
     "layer3": "",
-    "source": "bbj_riken.mpheno36"
+    "value": "bbj_riken.mpheno36"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Collagen diseases (connective tissue diseases)",
     "layer2": "Rheumatoid arthritis",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno36.male"
+    "value": "bbj_riken.mpheno36.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Collagen diseases (connective tissue diseases)",
     "layer2": "Rheumatoid arthritis",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno36.female"
+    "value": "bbj_riken.mpheno36.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Allergy",
     "layer2": "Hay fever",
     "layer3": "",
-    "source": "bbj_riken.mpheno37"
+    "value": "bbj_riken.mpheno37"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Allergy",
     "layer2": "Hay fever",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno37.male"
+    "value": "bbj_riken.mpheno37.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Allergy",
     "layer2": "Hay fever",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno37.female"
+    "value": "bbj_riken.mpheno37.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the skin and subcutaneous tissue",
     "layer2": "Drug eruption",
     "layer3": "",
-    "source": "bbj_riken.mpheno38"
+    "value": "bbj_riken.mpheno38"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the skin and subcutaneous tissue",
     "layer2": "Drug eruption",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno38.male"
+    "value": "bbj_riken.mpheno38.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the skin and subcutaneous tissue",
     "layer2": "Drug eruption",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno38.female"
+    "value": "bbj_riken.mpheno38.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the skin and subcutaneous tissue",
     "layer2": "Atopic dermatitis",
     "layer3": "",
-    "source": "bbj_riken.mpheno39"
+    "value": "bbj_riken.mpheno39"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the skin and subcutaneous tissue",
     "layer2": "Atopic dermatitis",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno39.male"
+    "value": "bbj_riken.mpheno39.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the skin and subcutaneous tissue",
     "layer2": "Atopic dermatitis",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno39.female"
+    "value": "bbj_riken.mpheno39.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the skin and subcutaneous tissue",
     "layer2": "Keloid",
     "layer3": "",
-    "source": "bbj_riken.mpheno40"
+    "value": "bbj_riken.mpheno40"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the skin and subcutaneous tissue",
     "layer2": "Keloid",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno40.male"
+    "value": "bbj_riken.mpheno40.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the skin and subcutaneous tissue",
     "layer2": "Keloid",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno40.female"
+    "value": "bbj_riken.mpheno40.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Gynecological diseases",
     "layer2": "Uterine fibroid",
     "layer3": "",
-    "source": "bbj_riken.mpheno41"
+    "value": "bbj_riken.mpheno41"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Gynecological diseases",
     "layer2": "Uterine fibroid",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno41.female"
+    "value": "bbj_riken.mpheno41.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Gynecological diseases",
     "layer2": "Endometriosis",
     "layer3": "",
-    "source": "bbj_riken.mpheno42"
+    "value": "bbj_riken.mpheno42"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Gynecological diseases",
     "layer2": "Endometriosis",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno42.female"
+    "value": "bbj_riken.mpheno42.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the eye and adnexa",
     "layer2": "Glaucoma",
     "layer3": "",
-    "source": "bbj_riken.mpheno44"
+    "value": "bbj_riken.mpheno44"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the eye and adnexa",
     "layer2": "Glaucoma",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno44.male"
+    "value": "bbj_riken.mpheno44.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the eye and adnexa",
     "layer2": "Glaucoma",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno44.female"
+    "value": "bbj_riken.mpheno44.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the eye and adnexa",
     "layer2": "Cataract",
     "layer3": "",
-    "source": "bbj_riken.mpheno45"
+    "value": "bbj_riken.mpheno45"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the eye and adnexa",
     "layer2": "Cataract",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno45.male"
+    "value": "bbj_riken.mpheno45.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Diseases of the eye and adnexa",
     "layer2": "Cataract",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno45.female"
+    "value": "bbj_riken.mpheno45.female"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Oral and Maxillofacial diseases",
     "layer2": "Periodontitis",
     "layer3": "",
-    "source": "bbj_riken.mpheno46"
+    "value": "bbj_riken.mpheno46"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Oral and Maxillofacial diseases",
     "layer2": "Periodontitis",
     "layer3": "Male",
-    "source": "bbj_riken.mpheno46.male"
+    "value": "bbj_riken.mpheno46.male"
   },
   {
     "dataset": () => "JGA-SNP",
     "layer1": "Oral and Maxillofacial diseases",
     "layer2": "Periodontitis",
     "layer3": "Female",
-    "source": "bbj_riken.mpheno46.female"
+    "value": "bbj_riken.mpheno46.female"
   },
   {
     "dataset": (assembly) => {
@@ -930,365 +930,365 @@ export const DATASETS = [
     "layer1": "Japanese",
     "layer2": "",
     "layer3": "",
-    "source": "tommo"
+    "value": "tommo"
   },
   {
     "dataset": () => "HGVD",
     "layer1": "Japanese",
     "layer2": "",
     "layer3": "",
-    "source": "hgvd"
+    "value": "hgvd"
   },
-  { "dataset": () => "NCBN", "layer1": "Total", "layer2": "", "layer3": "", "source": "ncbn" },
+  { "dataset": () => "NCBN", "layer1": "Total", "layer2": "", "layer3": "", "value": "ncbn" },
   {
     "dataset": () => "NCBN",
     "layer1": "Japanese",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.jpn"
+    "value": "ncbn.jpn"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Japanese",
     "layer2": "Hondo",
     "layer3": "",
-    "source": "ncbn.jpn.hondo"
+    "value": "ncbn.jpn.hondo"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Japanese",
     "layer2": "Ryukyu",
     "layer3": "",
-    "source": "ncbn.jpn.ryukyu"
+    "value": "ncbn.jpn.ryukyu"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "African Caribbean in Barbados",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.acb"
+    "value": "ncbn.acb"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "African Ancestry in SW USA",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.asw"
+    "value": "ncbn.asw"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Bengali in Bangladesh",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.beb"
+    "value": "ncbn.beb"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "British From England and Scotland",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.gbr"
+    "value": "ncbn.gbr"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Chinese Dai in Xishuangbanna, China",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.cdx"
+    "value": "ncbn.cdx"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Colombian in Medellín, Colombia",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.clm"
+    "value": "ncbn.clm"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Esan in Nigeria",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.esn"
+    "value": "ncbn.esn"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Finnish in Finland",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.fin"
+    "value": "ncbn.fin"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Gambian in Western Division – Mandinka",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.gwd"
+    "value": "ncbn.gwd"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Gujarati Indians in Houston, Texas, USA",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.gih"
+    "value": "ncbn.gih"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Han Chinese in Beijing, China",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.chb"
+    "value": "ncbn.chb"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Han Chinese South",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.chs"
+    "value": "ncbn.chs"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Iberian Populations in Spain",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.ibs"
+    "value": "ncbn.ibs"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Indian Telugu in the U.K.",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.itu"
+    "value": "ncbn.itu"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Japanese in Tokyo, Japan",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.jpt"
+    "value": "ncbn.jpt"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Kinh in Ho Chi Minh City, Vietnam",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.khv"
+    "value": "ncbn.khv"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Luhya in Webuye, Kenya",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.lwk"
+    "value": "ncbn.lwk"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Mende in Sierra Leone",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.msl"
+    "value": "ncbn.msl"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Mexican Ancestry in Los Angeles CA USA",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.mxl"
+    "value": "ncbn.mxl"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Peruvian in Lima Peru",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.pel"
+    "value": "ncbn.pel"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Puerto Rican in Puerto Rico",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.pur"
+    "value": "ncbn.pur"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Punjabi in Lahore, Pakistan",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.pjl"
+    "value": "ncbn.pjl"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Sri Lankan Tamil in the UK",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.stu"
+    "value": "ncbn.stu"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Toscani in Italia",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.tsi"
+    "value": "ncbn.tsi"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Utah residents (CEPH) with Northern and Western European ancestry",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.ceu"
+    "value": "ncbn.ceu"
   },
   {
     "dataset": () => "NCBN",
     "layer1": "Yoruba in Ibadan, Nigeria",
     "layer2": "",
     "layer3": "",
-    "source": "ncbn.yri"
+    "value": "ncbn.yri"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "Total",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes"
+    "value": "gnomad_genomes"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "African-American/African",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.afr"
+    "value": "gnomad_genomes.afr"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "Amish",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.ami"
+    "value": "gnomad_genomes.ami"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "Latino",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.amr"
+    "value": "gnomad_genomes.amr"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "Ashkenazi Jewish",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.asj"
+    "value": "gnomad_genomes.asj"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "East Asian",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.eas"
+    "value": "gnomad_genomes.eas"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "European (Finnish)",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.fin"
+    "value": "gnomad_genomes.fin"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "Middle Eastern",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.mid"
+    "value": "gnomad_genomes.mid"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "European (Non-Finnish)",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.nfe"
+    "value": "gnomad_genomes.nfe"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "Remaining",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.remaining"
+    "value": "gnomad_genomes.remaining"
   },
   {
     "dataset": () => "gnomAD Genomes",
     "layer1": "South Asian",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_genomes.sas"
+    "value": "gnomad_genomes.sas"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "Total",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes"
+    "value": "gnomad_exomes"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "African-American/African",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes.afr"
+    "value": "gnomad_exomes.afr"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "Latino",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes.amr"
+    "value": "gnomad_exomes.amr"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "Ashkenazi Jewish",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes.asj"
+    "value": "gnomad_exomes.asj"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "East Asian",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes.eas"
+    "value": "gnomad_exomes.eas"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "European (Finnish)",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes.fin"
+    "value": "gnomad_exomes.fin"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "Middle Eastern",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes.mid"
+    "value": "gnomad_exomes.mid"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "European (Non-Finnish)",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes.nfe"
+    "value": "gnomad_exomes.nfe"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "Remaining",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes.remaining"
+    "value": "gnomad_exomes.remaining"
   },
   {
     "dataset": () => "gnomAD Exomes",
     "layer1": "South Asian",
     "layer2": "",
     "layer3": "",
-    "source": "gnomad_exomes.sas"
+    "value": "gnomad_exomes.sas"
   }
 ]
 

--- a/stanzas/variant-frequency/index.js
+++ b/stanzas/variant-frequency/index.js
@@ -12,7 +12,7 @@ export default class VariantSummary extends Stanza {
 
     const assembly = this.params.assembly;
     const { "data-url": urlBase, tgv_id } = this.params;
-    const dataURL = `${urlBase}search?term=${tgv_id}&expand_dataset`;
+    const dataURL = `${urlBase}search?quality=0&term=${tgv_id}&expand_dataset`;
     let resultObject = [];
     let currentLayer1;
 
@@ -37,25 +37,31 @@ export default class VariantSummary extends Stanza {
 
       // バインディングを処理
       datasets.forEach(datum => {
-        const frequencyData = frequenciesDatasets?.find(x => x.source === datum.source);
+        const frequencyData = frequenciesDatasets?.find(x => x.source === datum.value);
 
         if (frequencyData) {
           const ac = parseInt(frequencyData.ac);
           const freq = parseFloat(frequencyData.af);
 
           // 数値をロケール形式の文字列に変換する関数
-          const localeString = (v) => v ? parseInt(v).toLocaleString() : null;
+          const localeString = (v) => v !== undefined ? parseInt(v).toLocaleString() : null;
 
           // バインディングにデータセット情報を追加
           frequencyData.dataset = datum.dataset(assembly);
           frequencyData.layer1 = datum.layer1;
           frequencyData.layer2 = datum.layer2;
           frequencyData.layer3 = datum.layer3;
-          frequencyData.ac = localeString(frequencyData?.ac);
-          frequencyData.an = localeString(frequencyData?.an);
-          frequencyData.aac = localeString(frequencyData?.aac);
-          frequencyData.arc = localeString(frequencyData?.arc);
-          frequencyData.rrc = localeString(frequencyData?.rrc);
+
+          // Alt
+          frequencyData.ac = localeString(frequencyData.ac);
+          // Total
+          frequencyData.an = localeString(frequencyData.an);
+          // Alt/Alt
+          frequencyData.aac = localeString(frequencyData.aac);
+          // Alt/Ref
+          frequencyData.arc = localeString(frequencyData.arc);
+          // Ref/Ref
+          frequencyData.rrc = localeString(frequencyData.rrc);
 
           // frequencyの情報をバインディングに追加
           Object.assign(frequencyData, frequency(ac, freq));


### PR DESCRIPTION
[issue#200](https://github.com/togovar/meeting/issues/200)の
①頻度スタンザ：Exclude filtered out variants in all datasetsのチェックを外す(quality=0)でAPIを検索する。
④頻度スタンザ：ncbnの頻度0が空白で表示されるので、0が表示されるようにする。
を修正しました。ご確認をお願いします。