### PR TITLE
Add functionality to download variantFrequency data in JSON, CSV, and TSV formats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",
-        "togostanza": "3.0.0-beta.55"
+        "togostanza": "3.0.0-beta.55",
+        "togostanza-utils": "github:togostanza/togostanza-utils"
       },
       "devDependencies": {
         "d3-hierarchy": "^3.1.2",
@@ -1911,7 +1912,6 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
       "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-      "peer": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -5160,6 +5160,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "node_modules/csv-stringify": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.6.0.tgz",
+      "integrity": "sha512-YW32lKOmIBgbxtu3g5SaiqWNwa/9ISQt2EcgOq0+RAIFufFp9is6tqNnKahqE5kuKvrnYAzs28r+s6pXJR8Vcw==",
+      "license": "MIT"
+    },
     "node_modules/d3": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
@@ -5587,6 +5593,22 @@
       "integrity": "sha512-5dVBvpBLBnPwSsYXqfybFyehMmC/EenKEcf23AhCTgTf48JFBbmJKqoZBsERDnjL0FyiVTYWdFsRfTLHxLyKdQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/dateformat": {
@@ -13261,8 +13283,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "peer": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -15741,6 +15762,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/togostanza-utils": {
+      "version": "0.0.0",
+      "resolved": "git+ssh://git@github.com/togostanza/togostanza-utils.git#1199a02667645d9313f7b35788044ca0750f5718",
+      "dependencies": {
+        "csv-stringify": "^6.0.5",
+        "d3": "^7.0.1",
+        "date-fns": "^2.27.0"
       }
     },
     "node_modules/togostanza/node_modules/fs-extra": {
@@ -19534,7 +19564,6 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
       "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
-      "peer": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -22002,6 +22031,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "csv-stringify": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.6.0.tgz",
+      "integrity": "sha512-YW32lKOmIBgbxtu3g5SaiqWNwa/9ISQt2EcgOq0+RAIFufFp9is6tqNnKahqE5kuKvrnYAzs28r+s6pXJR8Vcw=="
+    },
     "d3": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
@@ -22284,6 +22318,14 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-6.1.0.tgz",
       "integrity": "sha512-5dVBvpBLBnPwSsYXqfybFyehMmC/EenKEcf23AhCTgTf48JFBbmJKqoZBsERDnjL0FyiVTYWdFsRfTLHxLyKdQ=="
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
     },
     "dateformat": {
       "version": "4.6.3",
@@ -28130,8 +28172,7 @@
     "regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "peer": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "regenerator-transform": {
       "version": "0.15.2",
@@ -29954,6 +29995,15 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
         }
+      }
+    },
+    "togostanza-utils": {
+      "version": "git+ssh://git@github.com/togostanza/togostanza-utils.git#1199a02667645d9313f7b35788044ca0750f5718",
+      "from": "togostanza-utils@github:togostanza/togostanza-utils",
+      "requires": {
+        "csv-stringify": "^6.0.5",
+        "d3": "^7.0.1",
+        "date-fns": "^2.27.0"
       }
     },
     "toidentifier": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "d3": "^7.9.0",
-    "togostanza": "3.0.0-beta.55"
+    "togostanza": "3.0.0-beta.55",
+    "togostanza-utils": "github:togostanza/togostanza-utils"
   },
   "devDependencies": {
     "d3-hierarchy": "^3.1.2",

--- a/stanzas/variant-frequency/index.js
+++ b/stanzas/variant-frequency/index.js
@@ -11,10 +11,14 @@ import {
 export default class VariantFrequency extends Stanza {
   constructor() {
     super(...arguments);
-    this.data = null;
+    this.data = [];
   }
 
   menu() {
+    if (!this.data || this.data.length === 0) {
+      return [];
+    }
+
     return [
       downloadJSONMenuItem(this, "variant-frequency", this.data),
       downloadCSVMenuItem(this, "variant-frequency", this.data),

--- a/stanzas/variant-frequency/index.js
+++ b/stanzas/variant-frequency/index.js
@@ -2,8 +2,26 @@ import Stanza from "togostanza/stanza";
 import { hierarchy } from 'd3-hierarchy';
 import { DATASETS } from "@/lib/constants";
 import { frequency } from "@/lib/display";
+import {
+  downloadCSVMenuItem,
+  downloadJSONMenuItem,
+  downloadTSVMenuItem,
+} from "togostanza-utils";
 
-export default class VariantSummary extends Stanza {
+export default class VariantFrequency extends Stanza {
+  constructor() {
+    super(...arguments);
+    this.data = null;
+  }
+
+  menu() {
+    return [
+      downloadJSONMenuItem(this, "variant-frequency", this.data),
+      downloadCSVMenuItem(this, "variant-frequency", this.data),
+      downloadTSVMenuItem(this, "variant-frequency", this.data),
+    ];
+  }
+
   async render() {
     // font: Roboto Condensed
     this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
@@ -66,6 +84,9 @@ export default class VariantSummary extends Stanza {
       // レスポンスを JSON 形式でパース
       const responseDatasets = await response.json();
       const frequenciesDatasets = responseDatasets.data[0]?.frequencies
+
+      // データをインスタンスプロパティに保存
+      this.data = frequenciesDatasets;
 
       /** Searches for and processes data, updating frequency datasets and result objects.
       * @param {Object} datum - The current dataset object being processed. */

--- a/stanzas/variant-frequency/index.js
+++ b/stanzas/variant-frequency/index.js
@@ -85,7 +85,7 @@ export default class VariantFrequency extends Stanza {
       const responseDatasets = await response.json();
       const frequenciesDatasets = responseDatasets.data[0]?.frequencies
 
-      // データをインスタンスプロパティに保存
+      // Save data to instance property
       this.data = frequenciesDatasets;
 
       /** Searches for and processes data, updating frequency datasets and result objects.


### PR DESCRIPTION
[issue#305](https://github.com/togovar/meeting/issues/305) variantFrequencyのstanzaでJSON, CSV, TSVをダウンロードできるように変更しました。ご確認をお願いします。