### PR TITLE
Fix/frequency

### DIFF
--- a/assets/css/components/_frequency-popover.scss
+++ b/assets/css/components/_frequency-popover.scss
@@ -1,0 +1,136 @@
+@use "@/assets/css/foundation/variables" as *;
+@use "sass:color";
+
+main {
+  .frequency-popover {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+
+    .frequency-popover-trigger {
+      position: relative;
+      box-sizing: border-box;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0;
+      color: $COLOR_GRAY;
+      cursor: help;
+      background-color: transparent;
+      border: none;
+      transform: translateY(-2px);
+
+      &::before {
+        font-family: FontAwesome;
+        font-size: 10px;
+        content: var(--char-circle-info);
+      }
+
+      &:focus-visible {
+        outline: 2px solid color.adjust($COLOR_KEY, $lightness: 15%);
+        outline-offset: 2px;
+      }
+    }
+  }
+
+  .frequency-popover-panel {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: var(--z-index-frequency-popover);
+    display: block;
+    visibility: hidden;
+    padding: 10px;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.25;
+    color: #444;
+    text-align: left;
+    white-space: normal;
+    pointer-events: none;
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 10px 26px rgb(0 0 0 / 18%);
+    opacity: 0;
+    transition:
+      opacity 120ms ease,
+      visibility 120ms ease;
+
+    .frequency-popover-arrow {
+      position: absolute;
+      width: 10px;
+      height: 10px;
+      pointer-events: none;
+      background-color: white;
+      box-shadow: -3px -3px 5px rgb(0 0 0 / 4%);
+      transform: rotate(45deg);
+    }
+
+    &[data-placement="top"] .frequency-popover-arrow {
+      box-shadow: 3px 3px 5px rgb(0 0 0 / 4%);
+    }
+
+    &[data-open="true"] {
+      visibility: visible;
+      pointer-events: auto;
+      opacity: 1;
+    }
+
+    .frequency-popover-title {
+      display: block;
+      margin-bottom: 6px;
+      line-height: 1.2;
+
+      .frequency-popover-title-main {
+        display: block;
+        font-size: 12px;
+        font-weight: 700;
+      }
+
+      .frequency-popover-title-sub {
+        display: block;
+        font-size: 12px;
+        font-weight: 400;
+      }
+    }
+
+    .frequency-popover-section {
+      display: block;
+      padding-top: 14px;
+    }
+
+    .frequency-popover-list {
+      display: block;
+    }
+
+    .frequency-popover-item {
+      display: block;
+      padding: 7px 0;
+      border-top: 1px solid #d5dbe0;
+
+      &:first-child {
+        padding-top: 0;
+        border-top: none;
+      }
+
+      &:last-child {
+        padding-bottom: 0;
+      }
+
+      .frequency-popover-term {
+        display: inline-block;
+        padding: 2px 6px;
+        margin-bottom: 2px;
+        font-weight: 700;
+        line-height: 1.1;
+        background-color: #f3f5f7;
+        border-radius: 3px;
+      }
+
+      .frequency-popover-description {
+        display: block;
+      }
+    }
+  }
+}

--- a/assets/css/components/_frequency-popover.scss
+++ b/assets/css/components/_frequency-popover.scss
@@ -49,7 +49,6 @@ main {
     left: 0;
     z-index: var(--z-index-frequency-popover);
     display: block;
-    visibility: hidden;
     max-width: min(44rem, calc(100vw - 48px));
     padding: 10px;
     font-size: 12px;
@@ -64,9 +63,7 @@ main {
     border-radius: 7px;
     box-shadow: 0 10px 26px rgb(0 0 0 / 18%);
     opacity: 0;
-    transition:
-      opacity 120ms ease,
-      visibility 120ms ease;
+    transition: opacity 120ms ease;
 
     .frequency-popover-arrow,
     .filter-status-popover-arrow {
@@ -174,7 +171,6 @@ main {
     }
 
     &[data-open="true"] {
-      visibility: visible;
       pointer-events: auto;
       opacity: 1;
     }

--- a/assets/css/components/_frequency-popover.scss
+++ b/assets/css/components/_frequency-popover.scss
@@ -2,13 +2,15 @@
 @use "sass:color";
 
 main {
-  .frequency-popover {
+  .frequency-popover,
+  .filter-status-popover {
     position: relative;
     display: inline-flex;
     align-items: center;
     vertical-align: middle;
 
-    .frequency-popover-trigger {
+    .frequency-popover-trigger,
+    .filter-status-popover-trigger {
       position: relative;
       box-sizing: border-box;
       display: inline-flex;
@@ -34,41 +36,141 @@ main {
     }
   }
 
-  .frequency-popover-panel {
+  .frequency-popover-panel,
+  .filter-status-popover-panel {
+    --popover-bg-color: white;
+    --popover-fg-color: #444;
+    --popover-border-color: transparent;
+    --popover-arrow-color: white;
+    --popover-arrow-filter: none;
+
     position: fixed;
     top: 0;
     left: 0;
     z-index: var(--z-index-frequency-popover);
     display: block;
     visibility: hidden;
+    max-width: min(44rem, calc(100vw - 48px));
     padding: 10px;
     font-size: 12px;
     font-weight: 400;
     line-height: 1.25;
-    color: #444;
+    color: var(--popover-fg-color);
     text-align: left;
     white-space: normal;
     pointer-events: none;
-    background-color: white;
-    border-radius: 10px;
+    background-color: var(--popover-bg-color);
+    border: 1px solid var(--popover-border-color);
+    border-radius: 7px;
     box-shadow: 0 10px 26px rgb(0 0 0 / 18%);
     opacity: 0;
     transition:
       opacity 120ms ease,
       visibility 120ms ease;
 
-    .frequency-popover-arrow {
+    .frequency-popover-arrow,
+    .filter-status-popover-arrow {
       position: absolute;
-      width: 10px;
-      height: 10px;
+      width: 12px;
+      height: 6px;
       pointer-events: none;
-      background-color: white;
-      box-shadow: -3px -3px 5px rgb(0 0 0 / 4%);
-      transform: rotate(45deg);
+      filter: var(--popover-arrow-filter);
+
+      &::before,
+      &::after {
+        position: absolute;
+        content: "";
+      }
     }
 
-    &[data-placement="top"] .frequency-popover-arrow {
-      box-shadow: 3px 3px 5px rgb(0 0 0 / 4%);
+    &[data-placement^="top"] {
+      .frequency-popover-arrow,
+      .filter-status-popover-arrow {
+        &::before {
+          top: 0;
+          left: 0;
+          border-top: 6px solid var(--popover-arrow-color);
+          border-right: 6px solid transparent;
+          border-left: 6px solid transparent;
+        }
+
+        &::after {
+          top: -1px;
+          left: 1px;
+          width: 10px;
+          height: 2px;
+          background-color: var(--popover-arrow-color);
+        }
+      }
+    }
+
+    &[data-placement^="bottom"] {
+      .frequency-popover-arrow,
+      .filter-status-popover-arrow {
+        &::before {
+          bottom: 0;
+          left: 0;
+          border-right: 6px solid transparent;
+          border-bottom: 6px solid var(--popover-arrow-color);
+          border-left: 6px solid transparent;
+        }
+
+        &::after {
+          bottom: -1px;
+          left: 1px;
+          width: 10px;
+          height: 2px;
+          background-color: var(--popover-arrow-color);
+        }
+      }
+    }
+
+    &[data-placement^="left"] {
+      .frequency-popover-arrow,
+      .filter-status-popover-arrow {
+        width: 6px;
+        height: 12px;
+
+        &::before {
+          top: 0;
+          left: 0;
+          border-top: 6px solid transparent;
+          border-bottom: 6px solid transparent;
+          border-left: 6px solid var(--popover-arrow-color);
+        }
+
+        &::after {
+          top: 1px;
+          left: -1px;
+          width: 2px;
+          height: 10px;
+          background-color: var(--popover-arrow-color);
+        }
+      }
+    }
+
+    &[data-placement^="right"] {
+      .frequency-popover-arrow,
+      .filter-status-popover-arrow {
+        width: 6px;
+        height: 12px;
+
+        &::before {
+          top: 0;
+          right: 0;
+          border-top: 6px solid transparent;
+          border-right: 6px solid var(--popover-arrow-color);
+          border-bottom: 6px solid transparent;
+        }
+
+        &::after {
+          top: 1px;
+          right: -1px;
+          width: 2px;
+          height: 10px;
+          background-color: var(--popover-arrow-color);
+        }
+      }
     }
 
     &[data-open="true"] {
@@ -124,6 +226,7 @@ main {
         margin-bottom: 2px;
         font-weight: 700;
         line-height: 1.1;
+        color: $COLOR_BLACK;
         background-color: #f3f5f7;
         border-radius: 3px;
       }
@@ -131,6 +234,23 @@ main {
       .frequency-popover-description {
         display: block;
       }
+    }
+  }
+
+  .filter-status-popover-panel {
+    --popover-bg-color: #{$COLOR_BLACK};
+    --popover-fg-color: white;
+    --popover-border-color: white;
+    --popover-arrow-color: #{$COLOR_BLACK};
+    --popover-arrow-filter: none;
+
+    max-width: 24rem;
+    padding: 0.4rem 0.6rem;
+    font-size: 12px;
+
+    .filter-status-popover-content {
+      display: block;
+      margin: 0;
     }
   }
 }

--- a/assets/css/components/_frequency.scss
+++ b/assets/css/components/_frequency.scss
@@ -23,7 +23,7 @@ $frequency-block-counts: (
 );
 $frequency-na-border: #d4d3d1;
 $frequency-na-background: #f4f4f4;
-$frequency-marker-size: 7px;
+$frequency-marker-size: 9px;
 $frequency-marker-offset: -5px;
 $frequency-marker-gap: 1px;
 

--- a/assets/css/components/_frequency.scss
+++ b/assets/css/components/_frequency.scss
@@ -23,7 +23,6 @@ $frequency-block-counts: (
 );
 $frequency-na-border: #d4d3d1;
 $frequency-na-background: #f4f4f4;
-$frequency-marker-color: $COLOR_SIGN_DANGEROUS;
 $frequency-marker-size: 7px;
 $frequency-marker-offset: -5px;
 $frequency-marker-gap: 1px;
@@ -91,7 +90,6 @@ $frequency-marker-gap: 1px;
     display: block;
     width: $frequency-marker-size;
     height: $frequency-marker-size;
-    background-color: $frequency-marker-color;
     background-repeat: no-repeat;
     background-position: center;
     border-radius: 1.5px;

--- a/assets/css/foundation/_variables.scss
+++ b/assets/css/foundation/_variables.scss
@@ -50,9 +50,11 @@ $COLOR_SIGN_UNKNOWN: #bbba7e;
   // z-index
   --z-index-sticky-table-header: 10;
   --z-index-togostanza-menu: 10000;
+  --z-index-frequency-popover: 10010;
 
   // charactor
   // FontAwesome
   --char-lock: "\f023";
+  --char-circle-info: "\f05a";
   --char-excramation-triangle: "\f071";
 }

--- a/lib/floating-popover.ts
+++ b/lib/floating-popover.ts
@@ -34,121 +34,134 @@ export const setupFloatingPopover = (
 ) => {
   const controller = new AbortController();
   const { signal } = controller;
-  const trigger = root.querySelector<HTMLElement>(triggerSelector);
-  const panel = root.querySelector<HTMLElement>(panelSelector);
-  const arrowElement = arrowSelector
-    ? panel?.querySelector<HTMLElement>(arrowSelector)
-    : undefined;
+  const triggers = Array.from(
+    root.querySelectorAll<HTMLElement>(triggerSelector),
+  );
+  const panels = Array.from(root.querySelectorAll<HTMLElement>(panelSelector));
 
-  if (!trigger || !panel) {
+  if (triggers.length === 0 || panels.length === 0) {
     return () => controller.abort();
   }
 
-  const originalParent = panel.parentNode;
-  const originalNextSibling = panel.nextSibling;
+  if (triggers.length !== panels.length) {
+    console.warn(
+      `setupFloatingPopover found ${triggers.length} triggers and ${panels.length} panels for selectors "${triggerSelector}" and "${panelSelector}". Pairing by index.`,
+    );
+  }
+
   const floatingRoot = floatingRootSelector
     ? root.querySelector(floatingRootSelector)
     : undefined;
 
-  floatingRoot?.appendChild(panel);
-  panel.setAttribute("aria-hidden", "true");
+  triggers.forEach((trigger, index) => {
+    const panel = panels[index];
 
-  let hideTimer: number | undefined;
-  let cleanupAutoUpdate: (() => void) | undefined;
-  let isOpenRequested = false;
-
-  const updatePanelPosition = () => {
-    return computePosition(trigger, panel, {
-      placement,
-      strategy: "fixed",
-      middleware: [
-        offset(offsetValue),
-        flip({ padding }),
-        shift({ padding }),
-        ...(arrowElement ? [arrow({ element: arrowElement, padding })] : []),
-      ],
-    }).then(({ middlewareData, placement: computedPlacement, x, y }) => {
-      Object.assign(panel.style, {
-        left: `${x}px`,
-        top: `${y}px`,
-      });
-      panel.dataset.placement = computedPlacement;
-
-      if (!arrowElement) {
-        return;
-      }
-
-      const { x: arrowX, y: arrowY } = middlewareData.arrow ?? {};
-      const staticSide = {
-        bottom: "top",
-        left: "right",
-        right: "left",
-        top: "bottom",
-      }[computedPlacement.split("-")[0]];
-
-      Object.assign(arrowElement.style, {
-        bottom: "",
-        left: arrowX != null ? `${arrowX}px` : "",
-        right: "",
-        top: arrowY != null ? `${arrowY}px` : "",
-        [staticSide]: "-6px",
-      });
-    });
-  };
-
-  const showPanel = () => {
-    isOpenRequested = true;
-    panel.removeAttribute("aria-hidden");
-    if (hideTimer !== undefined) {
-      window.clearTimeout(hideTimer);
-      hideTimer = undefined;
+    if (!panel) {
+      return;
     }
-    void updatePanelPosition().then(() => {
-      if (!isOpenRequested || signal.aborted) {
-        return;
-      }
-      panel.setAttribute("data-open", "true");
-      cleanupAutoUpdate ??= autoUpdate(trigger, panel, updatePanelPosition);
-    });
-  };
 
-  const hidePanel = () => {
-    isOpenRequested = false;
-    if (hideTimer !== undefined) {
-      window.clearTimeout(hideTimer);
-    }
-    hideTimer = window.setTimeout(() => {
+    const arrowElement = arrowSelector
+      ? panel.querySelector<HTMLElement>(arrowSelector)
+      : undefined;
+    const originalParent = panel.parentNode;
+    const originalNextSibling = panel.nextSibling;
+
+    floatingRoot?.appendChild(panel);
+
+    let hideTimer: number | undefined;
+    let cleanupAutoUpdate: (() => void) | undefined;
+    let isOpenRequested = false;
+
+    const updatePanelPosition = () => {
+      return computePosition(trigger, panel, {
+        placement,
+        strategy: "fixed",
+        middleware: [
+          offset(offsetValue),
+          flip({ padding }),
+          shift({ padding }),
+          ...(arrowElement ? [arrow({ element: arrowElement, padding })] : []),
+        ],
+      }).then(({ middlewareData, placement: computedPlacement, x, y }) => {
+        Object.assign(panel.style, {
+          left: `${x}px`,
+          top: `${y}px`,
+        });
+        panel.dataset.placement = computedPlacement;
+
+        if (!arrowElement) {
+          return;
+        }
+
+        const { x: arrowX, y: arrowY } = middlewareData.arrow ?? {};
+        const staticSide = {
+          bottom: "top",
+          left: "right",
+          right: "left",
+          top: "bottom",
+        }[computedPlacement.split("-")[0]];
+
+        Object.assign(arrowElement.style, {
+          bottom: "",
+          left: arrowX != null ? `${arrowX}px` : "",
+          right: "",
+          top: arrowY != null ? `${arrowY}px` : "",
+          [staticSide]: "-6px",
+        });
+      });
+    };
+
+    const showPanel = () => {
+      isOpenRequested = true;
+      if (hideTimer !== undefined) {
+        window.clearTimeout(hideTimer);
+        hideTimer = undefined;
+      }
+      void updatePanelPosition().then(() => {
+        if (!isOpenRequested || signal.aborted) {
+          return;
+        }
+        panel.setAttribute("data-open", "true");
+        cleanupAutoUpdate ??= autoUpdate(trigger, panel, updatePanelPosition);
+      });
+    };
+
+    const hidePanel = () => {
+      isOpenRequested = false;
+      if (hideTimer !== undefined) {
+        window.clearTimeout(hideTimer);
+      }
+      hideTimer = window.setTimeout(() => {
+        panel.removeAttribute("data-open");
+        cleanupAutoUpdate?.();
+        cleanupAutoUpdate = undefined;
+        hideTimer = undefined;
+      }, hideDelay);
+    };
+
+    trigger.addEventListener("mouseenter", showPanel, { signal });
+    trigger.addEventListener("focus", showPanel, { signal });
+    trigger.addEventListener("mouseleave", hidePanel, { signal });
+    trigger.addEventListener("blur", hidePanel, { signal });
+    panel.addEventListener("mouseenter", showPanel, { signal });
+    panel.addEventListener("mouseleave", hidePanel, { signal });
+    signal.addEventListener("abort", () => {
+      isOpenRequested = false;
+      if (hideTimer !== undefined) {
+        window.clearTimeout(hideTimer);
+        hideTimer = undefined;
+      }
       panel.removeAttribute("data-open");
-      panel.setAttribute("aria-hidden", "true");
       cleanupAutoUpdate?.();
       cleanupAutoUpdate = undefined;
-      hideTimer = undefined;
-    }, hideDelay);
-  };
-
-  trigger.addEventListener("mouseenter", showPanel, { signal });
-  trigger.addEventListener("focus", showPanel, { signal });
-  trigger.addEventListener("mouseleave", hidePanel, { signal });
-  trigger.addEventListener("blur", hidePanel, { signal });
-  panel.addEventListener("mouseenter", showPanel, { signal });
-  panel.addEventListener("mouseleave", hidePanel, { signal });
-  signal.addEventListener("abort", () => {
-    isOpenRequested = false;
-    if (hideTimer !== undefined) {
-      window.clearTimeout(hideTimer);
-      hideTimer = undefined;
-    }
-    panel.removeAttribute("data-open");
-    panel.setAttribute("aria-hidden", "true");
-    cleanupAutoUpdate?.();
-    cleanupAutoUpdate = undefined;
-    if (originalParent && panel.parentNode !== originalParent) {
-      if (originalNextSibling?.parentNode === originalParent) {
-        originalParent.insertBefore(panel, originalNextSibling);
-      } else {
-        originalParent.appendChild(panel);
+      if (originalParent && panel.parentNode !== originalParent) {
+        if (originalNextSibling?.parentNode === originalParent) {
+          originalParent.insertBefore(panel, originalNextSibling);
+        } else {
+          originalParent.appendChild(panel);
+        }
       }
-    }
+    });
   });
 
   return () => controller.abort();

--- a/lib/floating-popover.ts
+++ b/lib/floating-popover.ts
@@ -105,10 +105,14 @@ export const setupFloatingPopover = (
   };
 
   const hidePanel = () => {
+    if (hideTimer !== undefined) {
+      window.clearTimeout(hideTimer);
+    }
     hideTimer = window.setTimeout(() => {
       panel.removeAttribute("data-open");
       cleanupAutoUpdate?.();
       cleanupAutoUpdate = undefined;
+      hideTimer = undefined;
     }, hideDelay);
   };
 

--- a/lib/floating-popover.ts
+++ b/lib/floating-popover.ts
@@ -121,10 +121,17 @@ export const setupFloatingPopover = (
   signal.addEventListener("abort", () => {
     if (hideTimer !== undefined) {
       window.clearTimeout(hideTimer);
+      hideTimer = undefined;
     }
+    panel.removeAttribute("data-open");
     cleanupAutoUpdate?.();
+    cleanupAutoUpdate = undefined;
     if (originalParent && panel.parentNode !== originalParent) {
-      originalParent.insertBefore(panel, originalNextSibling);
+      if (originalNextSibling?.parentNode === originalParent) {
+        originalParent.insertBefore(panel, originalNextSibling);
+      } else {
+        originalParent.appendChild(panel);
+      }
     }
   });
 

--- a/lib/floating-popover.ts
+++ b/lib/floating-popover.ts
@@ -70,7 +70,7 @@ export const setupFloatingPopover = (
         left: `${x}px`,
         top: `${y}px`,
       });
-      panel.dataset.placement = computedPlacement.split("-")[0];
+      panel.dataset.placement = computedPlacement;
 
       if (!arrowElement) {
         return;
@@ -89,7 +89,7 @@ export const setupFloatingPopover = (
         left: arrowX != null ? `${arrowX}px` : "",
         right: "",
         top: arrowY != null ? `${arrowY}px` : "",
-        [staticSide]: "-5px",
+        [staticSide]: "-6px",
       });
     });
   };

--- a/lib/floating-popover.ts
+++ b/lib/floating-popover.ts
@@ -51,12 +51,14 @@ export const setupFloatingPopover = (
     : undefined;
 
   floatingRoot?.appendChild(panel);
+  panel.setAttribute("aria-hidden", "true");
 
   let hideTimer: number | undefined;
   let cleanupAutoUpdate: (() => void) | undefined;
+  let isOpenRequested = false;
 
   const updatePanelPosition = () => {
-    void computePosition(trigger, panel, {
+    return computePosition(trigger, panel, {
       placement,
       strategy: "fixed",
       middleware: [
@@ -95,21 +97,29 @@ export const setupFloatingPopover = (
   };
 
   const showPanel = () => {
+    isOpenRequested = true;
+    panel.removeAttribute("aria-hidden");
     if (hideTimer !== undefined) {
       window.clearTimeout(hideTimer);
       hideTimer = undefined;
     }
-    panel.setAttribute("data-open", "true");
-    cleanupAutoUpdate ??= autoUpdate(trigger, panel, updatePanelPosition);
-    updatePanelPosition();
+    void updatePanelPosition().then(() => {
+      if (!isOpenRequested || signal.aborted) {
+        return;
+      }
+      panel.setAttribute("data-open", "true");
+      cleanupAutoUpdate ??= autoUpdate(trigger, panel, updatePanelPosition);
+    });
   };
 
   const hidePanel = () => {
+    isOpenRequested = false;
     if (hideTimer !== undefined) {
       window.clearTimeout(hideTimer);
     }
     hideTimer = window.setTimeout(() => {
       panel.removeAttribute("data-open");
+      panel.setAttribute("aria-hidden", "true");
       cleanupAutoUpdate?.();
       cleanupAutoUpdate = undefined;
       hideTimer = undefined;
@@ -123,11 +133,13 @@ export const setupFloatingPopover = (
   panel.addEventListener("mouseenter", showPanel, { signal });
   panel.addEventListener("mouseleave", hidePanel, { signal });
   signal.addEventListener("abort", () => {
+    isOpenRequested = false;
     if (hideTimer !== undefined) {
       window.clearTimeout(hideTimer);
       hideTimer = undefined;
     }
     panel.removeAttribute("data-open");
+    panel.setAttribute("aria-hidden", "true");
     cleanupAutoUpdate?.();
     cleanupAutoUpdate = undefined;
     if (originalParent && panel.parentNode !== originalParent) {

--- a/lib/floating-popover.ts
+++ b/lib/floating-popover.ts
@@ -1,0 +1,132 @@
+import {
+  arrow,
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  shift,
+  type Placement,
+} from "@floating-ui/dom";
+
+interface FloatingPopoverOptions {
+  triggerSelector: string;
+  panelSelector: string;
+  arrowSelector?: string;
+  floatingRootSelector?: string;
+  placement?: Placement;
+  offset?: number;
+  padding?: number;
+  hideDelay?: number;
+}
+
+export const setupFloatingPopover = (
+  root: ParentNode,
+  {
+    triggerSelector,
+    panelSelector,
+    arrowSelector,
+    floatingRootSelector,
+    placement = "bottom",
+    offset: offsetValue = 10,
+    padding = 16,
+    hideDelay = 100,
+  }: FloatingPopoverOptions,
+) => {
+  const controller = new AbortController();
+  const { signal } = controller;
+  const trigger = root.querySelector<HTMLElement>(triggerSelector);
+  const panel = root.querySelector<HTMLElement>(panelSelector);
+  const arrowElement = arrowSelector
+    ? panel?.querySelector<HTMLElement>(arrowSelector)
+    : undefined;
+
+  if (!trigger || !panel) {
+    return () => controller.abort();
+  }
+
+  const originalParent = panel.parentNode;
+  const originalNextSibling = panel.nextSibling;
+  const floatingRoot = floatingRootSelector
+    ? root.querySelector(floatingRootSelector)
+    : undefined;
+
+  floatingRoot?.appendChild(panel);
+
+  let hideTimer: number | undefined;
+  let cleanupAutoUpdate: (() => void) | undefined;
+
+  const updatePanelPosition = () => {
+    void computePosition(trigger, panel, {
+      placement,
+      strategy: "fixed",
+      middleware: [
+        offset(offsetValue),
+        flip({ padding }),
+        shift({ padding }),
+        ...(arrowElement ? [arrow({ element: arrowElement, padding })] : []),
+      ],
+    }).then(({ middlewareData, placement: computedPlacement, x, y }) => {
+      Object.assign(panel.style, {
+        left: `${x}px`,
+        top: `${y}px`,
+      });
+      panel.dataset.placement = computedPlacement.split("-")[0];
+
+      if (!arrowElement) {
+        return;
+      }
+
+      const { x: arrowX, y: arrowY } = middlewareData.arrow ?? {};
+      const staticSide = {
+        bottom: "top",
+        left: "right",
+        right: "left",
+        top: "bottom",
+      }[computedPlacement.split("-")[0]];
+
+      Object.assign(arrowElement.style, {
+        bottom: "",
+        left: arrowX != null ? `${arrowX}px` : "",
+        right: "",
+        top: arrowY != null ? `${arrowY}px` : "",
+        [staticSide]: "-5px",
+      });
+    });
+  };
+
+  const showPanel = () => {
+    if (hideTimer !== undefined) {
+      window.clearTimeout(hideTimer);
+      hideTimer = undefined;
+    }
+    panel.setAttribute("data-open", "true");
+    cleanupAutoUpdate ??= autoUpdate(trigger, panel, updatePanelPosition);
+    updatePanelPosition();
+  };
+
+  const hidePanel = () => {
+    hideTimer = window.setTimeout(() => {
+      panel.removeAttribute("data-open");
+      cleanupAutoUpdate?.();
+      cleanupAutoUpdate = undefined;
+    }, hideDelay);
+  };
+
+  trigger.addEventListener("mouseenter", showPanel, { signal });
+  trigger.addEventListener("focus", showPanel, { signal });
+  trigger.addEventListener("mouseleave", hidePanel, { signal });
+  trigger.addEventListener("blur", hidePanel, { signal });
+  panel.addEventListener("mouseenter", showPanel, { signal });
+  panel.addEventListener("mouseleave", hidePanel, { signal });
+  signal.addEventListener("abort", () => {
+    if (hideTimer !== undefined) {
+      window.clearTimeout(hideTimer);
+    }
+    cleanupAutoUpdate?.();
+    if (originalParent && panel.parentNode !== originalParent) {
+      originalParent.insertBefore(panel, originalNextSibling);
+    }
+  });
+
+  return () => controller.abort();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
+        "@floating-ui/dom": "^1.7.6",
         "d3": "^7.9.0",
         "togostanza": "3.0.0-beta.55",
         "togostanza-utils": "github:togostanza/togostanza-utils"
@@ -2079,6 +2080,31 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:css:fix": "stylelint \"**/*.scss\" --ignore-path .gitignore --fix"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.7.6",
     "d3": "^7.9.0",
     "togostanza": "3.0.0-beta.55",
     "togostanza-utils": "github:togostanza/togostanza-utils"

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -89,6 +89,11 @@ export default class VariantFrequency extends Stanza {
   /** 再描画時に popover のイベントリスナーを解除するために保持 */
   cleanupFrequencyPopovers: (() => void)[] = [];
 
+  private cleanupRenderedPopovers() {
+    this.cleanupFrequencyPopovers.forEach((cleanup) => cleanup());
+    this.cleanupFrequencyPopovers = [];
+  }
+
   // ============================================================
   // menu() — 右上のダウンロードメニューを構成
   // ============================================================
@@ -381,6 +386,7 @@ export default class VariantFrequency extends Stanza {
       );
 
       // HTMLテンプレートに渡してレンダリング
+      this.cleanupRenderedPopovers();
       this.renderTemplate({
         template: "stanza.html.hbs",
         parameters: {
@@ -389,7 +395,6 @@ export default class VariantFrequency extends Stanza {
           hasHemizygote,
         },
       });
-      this.cleanupFrequencyPopovers.forEach((cleanup) => cleanup());
       this.cleanupFrequencyPopovers = [
         setupFloatingPopover(this.root, {
           triggerSelector: ".frequency-popover-trigger",
@@ -410,6 +415,7 @@ export default class VariantFrequency extends Stanza {
       const message = e instanceof Error ? e.message : String(e);
 
       this.data = [];
+      this.cleanupRenderedPopovers();
       this.renderTemplate({
         template: "stanza.html.hbs",
         parameters: {

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -87,7 +87,7 @@ export default class VariantFrequency extends Stanza {
   data: FrequencyData[] = [];
 
   /** 再描画時に popover のイベントリスナーを解除するために保持 */
-  cleanupFrequencyPopover?: () => void;
+  cleanupFrequencyPopovers: (() => void)[] = [];
 
   // ============================================================
   // menu() — 右上のダウンロードメニューを構成
@@ -389,13 +389,23 @@ export default class VariantFrequency extends Stanza {
           hasHemizygote,
         },
       });
-      this.cleanupFrequencyPopover?.();
-      this.cleanupFrequencyPopover = setupFloatingPopover(this.root, {
-        triggerSelector: ".frequency-popover-trigger",
-        panelSelector: ".frequency-popover-panel",
-        arrowSelector: ".frequency-popover-arrow",
-        floatingRootSelector: "main",
-      });
+      this.cleanupFrequencyPopovers.forEach((cleanup) => cleanup());
+      this.cleanupFrequencyPopovers = [
+        setupFloatingPopover(this.root, {
+          triggerSelector: ".frequency-popover-trigger",
+          panelSelector: ".frequency-popover-panel",
+          arrowSelector: ".frequency-popover-arrow",
+          floatingRootSelector: "main",
+        }),
+        setupFloatingPopover(this.root, {
+          triggerSelector: ".filter-status-popover-trigger",
+          panelSelector: ".filter-status-popover-panel",
+          arrowSelector: ".filter-status-popover-arrow",
+          floatingRootSelector: "main",
+          placement: "top",
+          hideDelay: 300,
+        }),
+      ];
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
 

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -94,6 +94,10 @@ export default class VariantFrequency extends Stanza {
     this.cleanupFrequencyPopovers = [];
   }
 
+  disconnectedCallback() {
+    this.cleanupRenderedPopovers();
+  }
+
   // ============================================================
   // menu() — 右上のダウンロードメニューを構成
   // ============================================================

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -6,6 +6,7 @@ import {
   buildFrequencyMarkerState,
   formatLocaleInteger,
 } from "@/lib/frequency";
+import { setupFloatingPopover } from "@/lib/floating-popover";
 import {
   downloadCSVMenuItem,
   downloadJSONMenuItem,
@@ -84,6 +85,9 @@ const isLocalhostHost = (hostname: string): boolean => {
 export default class VariantFrequency extends Stanza {
   /** ダウンロードボタン用に保持するデータ */
   data: FrequencyData[] = [];
+
+  /** 再描画時に popover のイベントリスナーを解除するために保持 */
+  cleanupFrequencyPopover?: () => void;
 
   // ============================================================
   // menu() — 右上のダウンロードメニューを構成
@@ -384,6 +388,13 @@ export default class VariantFrequency extends Stanza {
           result: { resultObject },
           hasHemizygote,
         },
+      });
+      this.cleanupFrequencyPopover?.();
+      this.cleanupFrequencyPopover = setupFloatingPopover(this.root, {
+        triggerSelector: ".frequency-popover-trigger",
+        panelSelector: ".frequency-popover-panel",
+        arrowSelector: ".frequency-popover-arrow",
+        floatingRootSelector: "main",
       });
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);

--- a/stanzas/variant-frequency/metadata.json
+++ b/stanzas/variant-frequency/metadata.json
@@ -4,7 +4,7 @@
   },
   "@id": "variant-frequency",
   "stanza:label": "Variant / Frequency",
-  "stanza:definition": "Display alternative allele frequencies of the variant",
+  "stanza:definition": "Display alternate allele frequencies of the variant",
   "stanza:type": "Stanza",
   "stanza:display": "Table",
   "stanza:provider": "TogoVar",

--- a/stanzas/variant-frequency/style.scss
+++ b/stanzas/variant-frequency/style.scss
@@ -1,4 +1,5 @@
 @use "@/assets/css/common";
+@use "@/assets/css/components/frequency-popover";
 @use "@/assets/css/foundation/variables" as *;
 @use "sass:color";
 
@@ -76,6 +77,10 @@ main {
           color: $COLOR_BLACK;
           border: none;
           border-left: 1px solid #dee2e6;
+        }
+
+        &.genotype-count-heading {
+          position: relative;
         }
 
         &.frequency {

--- a/stanzas/variant-frequency/templates/stanza.html.hbs
+++ b/stanzas/variant-frequency/templates/stanza.html.hbs
@@ -78,7 +78,29 @@
               </span>
             </span>
           </th>
-          <th class='filter_status' rowspan='2'>Filter status</th>
+          <th class='filter_status' rowspan='2'>
+            Filter status
+            <span class='filter-status-popover'>
+              <button
+                class='filter-status-popover-trigger'
+                type='button'
+                aria-label='Show filter status descriptions'
+                aria-describedby='filter-status-popover'
+              ></button>
+              <span
+                class='filter-status-popover-panel'
+                id='filter-status-popover'
+                role='tooltip'
+              >
+                <span class='filter-status-popover-arrow'></span>
+                <span class='filter-status-popover-content'>
+                  Variant quality filter status reported by the source dataset.<br>
+                  PASS indicates the variant passed all quality filters.<br>
+                  Other values indicate the variant failed one or more filters.
+                </span>
+              </span>
+            </span>
+          </th>
           <th rowspan='2'>Quality score</th>
         </tr>
         <tr>

--- a/stanzas/variant-frequency/templates/stanza.html.hbs
+++ b/stanzas/variant-frequency/templates/stanza.html.hbs
@@ -30,27 +30,27 @@
                 </span>
                 <span class='frequency-popover-list'>
                   <span class='frequency-popover-item'>
-                    <span class='frequency-popover-term'>Alt / Alt</span>
+                    <span class='frequency-popover-term'>Alt/Alt</span>
                     <span class='frequency-popover-description'>Homozygous for the target alternate allele</span>
                   </span>
                   <span class='frequency-popover-item'>
-                    <span class='frequency-popover-term'>Alt / Ref</span>
+                    <span class='frequency-popover-term'>Alt/Ref</span>
                     <span class='frequency-popover-description'>Heterozygous for the target alternate allele and the reference allele</span>
                   </span>
                   <span class='frequency-popover-item'>
-                    <span class='frequency-popover-term'>Alt / OtherAlts</span>
+                    <span class='frequency-popover-term'>Alt/OtherAlts</span>
                     <span class='frequency-popover-description'>Heterozygous for the target alternate allele and another alternate allele</span>
                   </span>
                   <span class='frequency-popover-item'>
-                    <span class='frequency-popover-term'>Ref / Ref</span>
+                    <span class='frequency-popover-term'>Ref/Ref</span>
                     <span class='frequency-popover-description'>Homozygous for the reference allele</span>
                   </span>
                   <span class='frequency-popover-item'>
-                    <span class='frequency-popover-term'>Ref / OtherAlts</span>
+                    <span class='frequency-popover-term'>Ref/OtherAlts</span>
                     <span class='frequency-popover-description'>Heterozygous for the reference allele and another alternate allele</span>
                   </span>
                   <span class='frequency-popover-item'>
-                    <span class='frequency-popover-term'>OtherAlts / OtherAlts</span>
+                    <span class='frequency-popover-term'>Other_Alts/Other_Alts</span>
                     <span class='frequency-popover-description'>Homozygous or heterozygous for other alternate allele(s)</span>
                   </span>
                 </span>

--- a/stanzas/variant-frequency/templates/stanza.html.hbs
+++ b/stanzas/variant-frequency/templates/stanza.html.hbs
@@ -9,7 +9,75 @@
           <th rowspan='2'>Dataset</th>
           <th rowspan='2'>Population</th>
           <th colspan='4'>Allele count</th>
-          <th colspan='{{#if ../hasHemizygote}}9{{else}}6{{/if}}'>Genotype count</th>
+          <th class='genotype-count-heading' colspan='{{#if ../hasHemizygote}}9{{else}}6{{/if}}'>
+            Genotype count
+            <span class='frequency-popover'>
+              <button
+                class='frequency-popover-trigger'
+                type='button'
+                aria-label='Show genotype count descriptions'
+                aria-describedby='genotype-count-popover'
+              ></button>
+              <span
+                class='frequency-popover-panel'
+                id='genotype-count-popover'
+                role='tooltip'
+              >
+                <span class='frequency-popover-arrow'></span>
+                <span class='frequency-popover-title'>
+                  <span class='frequency-popover-title-main'>Diploid regions in autosomes and chrX</span>
+                  <span class='frequency-popover-title-sub'>all chrX regions in females and pseudoautosomal regions (PARs) in males</span>
+                </span>
+                <span class='frequency-popover-list'>
+                  <span class='frequency-popover-item'>
+                    <span class='frequency-popover-term'>Alt / Alt</span>
+                    <span class='frequency-popover-description'>Homozygous for the target alternate allele</span>
+                  </span>
+                  <span class='frequency-popover-item'>
+                    <span class='frequency-popover-term'>Alt / Ref</span>
+                    <span class='frequency-popover-description'>Heterozygous for the target alternate allele and the reference allele</span>
+                  </span>
+                  <span class='frequency-popover-item'>
+                    <span class='frequency-popover-term'>Alt / OtherAlts</span>
+                    <span class='frequency-popover-description'>Heterozygous for the target alternate allele and another alternate allele</span>
+                  </span>
+                  <span class='frequency-popover-item'>
+                    <span class='frequency-popover-term'>Ref / Ref</span>
+                    <span class='frequency-popover-description'>Homozygous for the reference allele</span>
+                  </span>
+                  <span class='frequency-popover-item'>
+                    <span class='frequency-popover-term'>Ref / OtherAlts</span>
+                    <span class='frequency-popover-description'>Heterozygous for the reference allele and another alternate allele</span>
+                  </span>
+                  <span class='frequency-popover-item'>
+                    <span class='frequency-popover-term'>OtherAlts / OtherAlts</span>
+                    <span class='frequency-popover-description'>Homozygous or heterozygous for other alternate allele(s)</span>
+                  </span>
+                </span>
+                {{#if ../hasHemizygote}}
+                  <span class='frequency-popover-section'>
+                    <span class='frequency-popover-title'>
+                      <span class='frequency-popover-title-main'>Haploid regions in non-pseudoautosomal regions of chrX and chrY in males</span>
+                    </span>
+                    <span class='frequency-popover-list'>
+                      <span class='frequency-popover-item'>
+                        <span class='frequency-popover-term'>Hemi_Alt</span>
+                        <span class='frequency-popover-description'>Hemizygous for the target alternate allele</span>
+                      </span>
+                      <span class='frequency-popover-item'>
+                        <span class='frequency-popover-term'>Hemi_Ref</span>
+                        <span class='frequency-popover-description'>Hemizygous for the reference allele</span>
+                      </span>
+                      <span class='frequency-popover-item'>
+                        <span class='frequency-popover-term'>Hemi_Other_Alt</span>
+                        <span class='frequency-popover-description'>Hemizygous for another alternate allele</span>
+                      </span>
+                    </span>
+                  </span>
+                {{/if}}
+              </span>
+            </span>
+          </th>
           <th class='filter_status' rowspan='2'>Filter status</th>
           <th rowspan='2'>Quality score</th>
         </tr>

--- a/stanzas/variant-frequency/templates/stanza.html.hbs
+++ b/stanzas/variant-frequency/templates/stanza.html.hbs
@@ -69,7 +69,7 @@
                         <span class='frequency-popover-description'>Hemizygous for the reference allele</span>
                       </span>
                       <span class='frequency-popover-item'>
-                        <span class='frequency-popover-term'>Hemi_Other_Alt</span>
+                        <span class='frequency-popover-term'>Hemi_Other_Alts</span>
                         <span class='frequency-popover-description'>Hemizygous for another alternate allele</span>
                       </span>
                     </span>

--- a/stanzas/variant-frequency/templates/stanza.html.hbs
+++ b/stanzas/variant-frequency/templates/stanza.html.hbs
@@ -22,6 +22,7 @@
                 class='frequency-popover-panel'
                 id='genotype-count-popover'
                 role='tooltip'
+                aria-hidden='true'
               >
                 <span class='frequency-popover-arrow'></span>
                 <span class='frequency-popover-title'>
@@ -91,6 +92,7 @@
                 class='filter-status-popover-panel'
                 id='filter-status-popover'
                 role='tooltip'
+                aria-hidden='true'
               >
                 <span class='filter-status-popover-arrow'></span>
                 <span class='filter-status-popover-content'>

--- a/stanzas/variant-frequency/templates/stanza.html.hbs
+++ b/stanzas/variant-frequency/templates/stanza.html.hbs
@@ -22,7 +22,6 @@
                 class='frequency-popover-panel'
                 id='genotype-count-popover'
                 role='tooltip'
-                aria-hidden='true'
               >
                 <span class='frequency-popover-arrow'></span>
                 <span class='frequency-popover-title'>
@@ -92,7 +91,6 @@
                 class='filter-status-popover-panel'
                 id='filter-status-popover'
                 role='tooltip'
-                aria-hidden='true'
               >
                 <span class='filter-status-popover-arrow'></span>
                 <span class='filter-status-popover-content'>


### PR DESCRIPTION
tooltipを追加しました。ご確認をお願いします。

This pull request introduces floating popover tooltips for the "Genotype count" and "Filter status" columns in the variant frequency table, enhancing user understanding with accessible, context-sensitive descriptions. The implementation includes new SCSS styles, a reusable TypeScript utility for floating popovers, and integration into the variant frequency stanza. Minor copy and variable updates are also included.

**Popover Functionality and Integration**
- Added a reusable `setupFloatingPopover` utility in `lib/floating-popover.ts` using `@floating-ui/dom` for positioning and managing popover tooltips, and integrated it into the variant frequency stanza to provide tooltips for "Genotype count" and "Filter status" headers (`lib/floating-popover.ts`, `stanzas/variant-frequency/index.ts`, `package.json`) [[1]](diffhunk://#diff-c8710e88852cde0d33cff48d28eacb3e8531e37b3ec373b262f44430805984cfR1-R132) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R21) [[3]](diffhunk://#diff-410b4bc46b06ae4d14c8ef360379b90cc6709665058c27c60514d4581dbbba3dR9) [[4]](diffhunk://#diff-410b4bc46b06ae4d14c8ef360379b90cc6709665058c27c60514d4581dbbba3dR89-R91) [[5]](diffhunk://#diff-410b4bc46b06ae4d14c8ef360379b90cc6709665058c27c60514d4581dbbba3dR392-R408).
- Updated the table template to include popover triggers and panels with detailed descriptions for genotype counts and filter status (`stanzas/variant-frequency/templates/stanza.html.hbs`).

**Styling and Accessibility**
- Added new SCSS styles for `.frequency-popover` and `.filter-status-popover`, including positioning, transitions, arrow styling, and accessibility improvements (`assets/css/components/_frequency-popover.scss`, `stanzas/variant-frequency/style.scss`) [[1]](diffhunk://#diff-17d2d85700689625950fbb20b1ea743e705597797e8445a03f254dd88b8c3ad4R1-R256) [[2]](diffhunk://#diff-00e4770de55eba9afa9177d6dd0bd26cc855a93742db89e5beaae64d0d94b0b7R2) [[3]](diffhunk://#diff-00e4770de55eba9afa9177d6dd0bd26cc855a93742db89e5beaae64d0d94b0b7R82-R85).
- Introduced new CSS variables for popover z-index and icon characters (`assets/css/foundation/_variables.scss`).

**Minor Improvements**
- Corrected a minor typo in the stanza definition ("alternative" → "alternate") (`stanzas/variant-frequency/metadata.json`).
- Removed an unused marker color variable from frequency SCSS for cleanup (`assets/css/components/_frequency.scss`) [[1]](diffhunk://#diff-3cefd5d4313d5b7971ee66ba6b03b685203178c9e3e459d2f0f772a1d18dbcbaL26) [[2]](diffhunk://#diff-3cefd5d4313d5b7971ee66ba6b03b685203178c9e3e459d2f0f772a1d18dbcbaL94).