### PR TITLE
Refactor/shared constants and gene link

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,3 +1,7 @@
+// TogoVar標準フォント。複数stanzaでimportWebFontCSSに渡す共通URL。
+export const ROBOTO_CONDENSED_CSS_URL =
+  "https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900";
+
 export const DATASETS = [
   {
     "value": "gem_j_wga",

--- a/lib/display.ts
+++ b/lib/display.ts
@@ -82,6 +82,21 @@ export const refAlt = (
   };
 };
 
+/**
+ * reference URI の末尾2セグメントから染色体名とアセンブリ名を取り出す。
+ * 例: "http://identifiers.org/hco/1/GRCh38" → { chr: "1", assembly: "GRCh38" }
+ */
+export const referenceToChrAssembly = (
+  referenceUri?: string,
+): { chr?: string; assembly?: string } => {
+  if (!referenceUri) {
+    return {};
+  }
+
+  const [chr, assembly] = referenceUri.split("/").slice(-2);
+  return { chr, assembly };
+};
+
 export const variantType = (accession?: string): { type: string } => ({
   type: (SO as LabelMap)[String(accession)]?.label || "Unknown",
 });

--- a/stanzas/disease-mgend/index.js
+++ b/stanzas/disease-mgend/index.js
@@ -1,11 +1,11 @@
 import Stanza from "togostanza/stanza";
 
-import { CLINICAL_SIGNIFICANCE } from "@/lib/constants";
+import { CLINICAL_SIGNIFICANCE, ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
 import { rowSpanize } from "@/lib/table";
 
 export default class DiseaseMGeND extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const { "data-url": dataURL, term } = this.params;
 

--- a/stanzas/gene-header/index.js
+++ b/stanzas/gene-header/index.js
@@ -1,9 +1,11 @@
 import Stanza from "togostanza/stanza";
 import {grouping, unwrapValueFromBinding} from "togostanza/utils";
 
+import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
+
 export default class GeneHeader extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/gene_header?hgnc_id=${this.params.hgnc_id}`);
 

--- a/stanzas/gene-mgend/index.js
+++ b/stanzas/gene-mgend/index.js
@@ -1,11 +1,11 @@
 import Stanza from "togostanza/stanza";
 
-import { CLINICAL_SIGNIFICANCE } from "@/lib/constants";
+import { CLINICAL_SIGNIFICANCE, ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
 import { rowSpanize } from "@/lib/table";
 
 export default class GeneMGeND extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const { "data-url": dataURL, term } = this.params;
 

--- a/stanzas/gene-protein-browser/index.js
+++ b/stanzas/gene-protein-browser/index.js
@@ -2,10 +2,12 @@ import Stanza from 'togostanza/stanza';
 
 import * as d3 from 'd3';
 
+import {ROBOTO_CONDENSED_CSS_URL} from '@/lib/constants';
+
 export default class GeneProteinBrowser extends Stanza {
   async render() {
 
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
     this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Mono:200,400,500,600");
     
     this.renderTemplate(

--- a/stanzas/gene-publication/index.js
+++ b/stanzas/gene-publication/index.js
@@ -1,8 +1,10 @@
 import Stanza from "@/lib/stanza";
 
+import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
+
 export default class GenePublication extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/gene_publication?hgnc_id=${this.params.hgnc_id}`);
 

--- a/stanzas/variant-clinvar/index.js
+++ b/stanzas/variant-clinvar/index.js
@@ -1,12 +1,12 @@
 import Stanza from "togostanza/stanza";
 import {unwrapValueFromBinding} from "togostanza/utils";
 
-import {CLINICAL_SIGNIFICANCE, REVIEW_STATUS} from "@/lib/constants";
+import {CLINICAL_SIGNIFICANCE, REVIEW_STATUS, ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
 import {rowSpanize} from "@/lib/table";
 
 export default class VariantSummary extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_clinvar?tgv_id=${this.params.tgv_id}`);
 

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -1,6 +1,6 @@
 import Stanza from "togostanza/stanza";
 import { hierarchy } from "d3-hierarchy";
-import { DATASETS } from "@/lib/constants";
+import { DATASETS, ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
 import {
   buildFrequencyDisplay,
   buildFrequencyMarkerState,
@@ -120,9 +120,7 @@ export default class VariantFrequency extends Stanza {
 
   async render() {
     // フォントの読み込み
-    this.importWebFontCSS(
-      "https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900",
-    );
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
     // データセットアイコン用フォント
     this.importWebFontCSS(
       new URL("./assets/fontello.css", import.meta.url).href,

--- a/stanzas/variant-gene/index.js
+++ b/stanzas/variant-gene/index.js
@@ -1,9 +1,11 @@
 import Stanza from "togostanza/stanza";
 import {grouping, unwrapValueFromBinding} from "togostanza/utils";
 
+import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
+
 export default class VariantGene extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_gene?tgv_id=${this.params.tgv_id}`);
 

--- a/stanzas/variant-genomic-context/index.js
+++ b/stanzas/variant-genomic-context/index.js
@@ -1,6 +1,8 @@
 import Stanza from "togostanza/stanza";
 import {unwrapValueFromBinding} from "togostanza/utils";
 
+import {referenceToChrAssembly} from "@/lib/display";
+
 export default class VariantSummary extends Stanza {
   async render() {
     const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_summary?tgv_id=${this.params.tgv_id}`);
@@ -22,7 +24,7 @@ export default class VariantSummary extends Stanza {
         return {error: {message: `Failed to obtain genomic position for ${this.params.tgv_id}`}};
       }
 
-      const chr = binding.reference.split("/").slice(-2)[0];
+      const { chr } = referenceToChrAssembly(binding.reference);
       const from = parseInt(binding.position);
       const to = from + Math.max(binding.ref.length - 1, 0);
       const range = parseInt(this.params.margin) || 50;

--- a/stanzas/variant-genomic-context/metadata.json
+++ b/stanzas/variant-genomic-context/metadata.json
@@ -17,7 +17,7 @@
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
-      "stanza:example": "tgv132831",
+      "stanza:example": "tgv219804",
       "stanza:description": "TogoVar ID",
       "stanza:required": true
     },

--- a/stanzas/variant-header/index.js
+++ b/stanzas/variant-header/index.js
@@ -2,10 +2,11 @@ import Stanza from "togostanza/stanza";
 import {unwrapValueFromBinding} from "togostanza/utils";
 
 import uniq from "@/lib/uniq";
+import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
 
 export default class VariantHeader extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?tgv_id=${this.params.tgv_id}`);
 

--- a/stanzas/variant-mgend/index.js
+++ b/stanzas/variant-mgend/index.js
@@ -1,11 +1,11 @@
 import Stanza from "togostanza/stanza";
 
-import { CLINICAL_SIGNIFICANCE } from "@/lib/constants";
+import { CLINICAL_SIGNIFICANCE, ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
 import { rowSpanize } from "@/lib/table";
 
 export default class VariantMGeND extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const { "data-url": dataURL, tgv_id } = this.params;
 

--- a/stanzas/variant-other-overlapping-variants/index.js
+++ b/stanzas/variant-other-overlapping-variants/index.js
@@ -1,10 +1,11 @@
 import Stanza from "togostanza/stanza";
 
 import {transformRecord} from "@/lib/display";
+import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
 
 export default class VariantSummary extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_other_alternative_alleles?tgv_id=${this.params.tgv_id}`)
 

--- a/stanzas/variant-publication/index.js
+++ b/stanzas/variant-publication/index.js
@@ -1,11 +1,13 @@
 import Stanza from "@/lib/stanza";
 import {unwrapValueFromBinding} from "togostanza/utils";
 
+import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
+
 const RS_PREFIX = "http://identifiers.org/dbsnp/";
 
 export default class VariantPublication extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?tgv_id=${this.params.tgv_id}`);
 

--- a/stanzas/variant-summary/index.js
+++ b/stanzas/variant-summary/index.js
@@ -1,12 +1,12 @@
 import Stanza from "togostanza/stanza";
-import {grouping, unwrapValueFromBinding} from "togostanza/utils";
+import {unwrapValueFromBinding} from "togostanza/utils";
 
-import uniq from "@/lib/uniq";
 import * as display from "@/lib/display";
+import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
 
 export default class VariantSummary extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_summary?tgv_id=${this.params.tgv_id}`);
 
@@ -25,8 +25,7 @@ export default class VariantSummary extends Stanza {
       let binding = bindings[0];
 
       if (binding) {
-        [binding.chr, binding.assembly] = binding.reference.split("/").slice(-2);
-
+        Object.assign(binding, display.referenceToChrAssembly(binding.reference));
         Object.assign(binding, display.refAlt(binding.ref, binding.alt));
       }
 

--- a/stanzas/variant-transcript/index.js
+++ b/stanzas/variant-transcript/index.js
@@ -2,10 +2,11 @@ import Stanza from "togostanza/stanza";
 import {unwrapValueFromBinding} from "togostanza/utils";
 
 import {alphaMissense, sift, polyphen} from "@/lib/display";
+import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
 
 export default class VariantTranscript extends Stanza {
   async render() {
-    this.importWebFontCSS("https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,700,900");
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/variant_transcript?tgv_id=${this.params.tgv_id}`);
 


### PR DESCRIPTION
Roboto Condensed web fontの定義をconstants.jsで行うよう変更しました。

This pull request refactors the way the Roboto Condensed web font is imported across multiple stanza components, centralizing the font URL in a constant and updating all usages to reference it. Additionally, it introduces a utility function to consistently extract chromosome and assembly names from reference URIs, and updates relevant components to use this function for improved code clarity and maintainability.

**Font import centralization:**

* Added `ROBOTO_CONDENSED_CSS_URL` constant in `lib/constants.js` and updated all stanza components to use this constant when importing the Roboto Condensed web font, replacing hardcoded URLs. This improves maintainability and consistency across the codebase. [[1]](diffhunk://#diff-602f56bb692d9bf3bdc5fef3d75d5fa33fe841c3d21ca46294bb6fdaf0785d0cR1-R4) [[2]](diffhunk://#diff-7132b8a709ed8628bd8e8be3f0f1341c99450dac7caab0984c3de482e1a82818L3-R8) [[3]](diffhunk://#diff-7c9a9aaee8b7f7e9bd89a5ea2e7d6cd341df1e81827114a3825ea62586722f99R4-R8) [[4]](diffhunk://#diff-9e2ac1aefb9bdecf617c794267a5d78e2035b4e39958c58ffc5c6a10b65fc85aL3-R8) [[5]](diffhunk://#diff-a75384cc6548e164eeeb5d615f58760d2f6ff12ec2e7bdc77edb665f94924cf3R5-R10) [[6]](diffhunk://#diff-023369cd7e62b376f191c071d6094794560c20e632b9921460b01ee752b789d6R3-R7) [[7]](diffhunk://#diff-4055325839f4d7cc4eef25a264fd5e3c265dd2f6166025f4874da65f1aa619d6L4-R9) [[8]](diffhunk://#diff-410b4bc46b06ae4d14c8ef360379b90cc6709665058c27c60514d4581dbbba3dL3-R3) [[9]](diffhunk://#diff-410b4bc46b06ae4d14c8ef360379b90cc6709665058c27c60514d4581dbbba3dL123-R123) [[10]](diffhunk://#diff-471c4ec3642b48b284eef216f5fc542ebc08e3d6c9786335d1656a4c8682a947R4-R8) [[11]](diffhunk://#diff-3d011139a441d6c947e16673ae655aa53d295201db1956a657de3396e29ee14dR5-R9) [[12]](diffhunk://#diff-7561d3248a8570d8eadba0fe3398638a90775197730e48d7abed09e74d6fc2fdL3-R8) [[13]](diffhunk://#diff-b1b3a98d70bdaa78f432d77d1e68fb824c952c24da077733785216933666b3d5R4-R8) [[14]](diffhunk://#diff-8411aa748e9a8aceb2ca5d91538e219ee4656f711dd464e7334716dde663ab14R4-R10) [[15]](diffhunk://#diff-fab16e7101adba9c733e7c007480c4fa2493bc3a068c7a19eddd441fda3531f0L2-R9) [[16]](diffhunk://#diff-6d170dcf6f07d434142d492efba7b2cebf9b9444bd3e4899636c5d5740429debR5-R9)

**Reference URI parsing improvements:**

* Added `referenceToChrAssembly` utility function in `lib/display.ts` to extract chromosome and assembly names from reference URIs, and updated relevant stanza components to use this function instead of manual string splitting. This enhances code readability and reduces duplication. [[1]](diffhunk://#diff-7816407bec701848b14773aa862482d0a21c4a1d71bb9ce73530471a0a6187a5R85-R99) [[2]](diffhunk://#diff-2e10516be642c92a28e0f8f5a59f8d969cb5de11dffdf681667c5de6b97caeb2R4-R5) [[3]](diffhunk://#diff-2e10516be642c92a28e0f8f5a59f8d969cb5de11dffdf681667c5de6b97caeb2L25-R27) [[4]](diffhunk://#diff-fab16e7101adba9c733e7c007480c4fa2493bc3a068c7a19eddd441fda3531f0L28-R28)

**Minor updates:**

* Updated the example `tgv_id` in `stanzas/variant-genomic-context/metadata.json` for clarity.