### PR TITLE
Fix/fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ variant系stanzaは、主に SPARQList と TogoVar検索APIを使います。`va
 
 - TogoVar検索APIを使うstanzaの `data-url` は、TogoVar API base URL または `/api/search/variant` endpoint のどちらを指定しても動くように正規化しています。
 - `tgv_id` と `variant` の両方が指定された場合は、全体方針として `tgv_id` を優先します。
+- `tgv2rs` は TogoVar ID (`tgv_id`) から RefSNP ID (`rsID`) を取得するSPARQList endpointです。`variant` は直接解釈しないため、必要なstanzaでは先にTogoVar検索APIで `tgv_id` に解決してから呼び出します。
 - SPARQListを使うstanzaで `variant` を指定する場合は、対応するSPARQList endpoint 側も `variant` を解決できる必要があります。
 
 ## このリポジトリのブランチ運用

--- a/README.md
+++ b/README.md
@@ -113,11 +113,36 @@ togostanza-build.mjs
 - `variant-gene`
 - `variant-genomic-context`
 - `variant-header`
+- `variant-links`
 - `variant-mgend`
 - `variant-other-overlapping-variants`
 - `variant-publication`
 - `variant-summary`
 - `variant-transcript`
+
+### variant系stanzaの利用API
+
+variant系stanzaは、主に SPARQList と TogoVar検索APIを使います。`variant` パラメータ（VCF representation: `CHROM-POS-REF-ALT`）への対応方法はstanzaごとに異なります。
+
+| Stanza | 主なAPI | Endpoint / URL | `variant` 指定時の扱い |
+| --- | --- | --- | --- |
+| `variant-clinvar` | SPARQList | `/api/variant_clinvar` | SPARQList endpoint へ `variant` を渡す |
+| `variant-frequency` | TogoVar検索API | `/api/search/variant`, `/search`, `/auth/status` | `/api/search/variant` で `tgv_id` に解決し、頻度取得は `/search?term=<tgv_id>` を使う |
+| `variant-gene` | SPARQList | `/api/variant_gene` | SPARQList endpoint へ `variant` を渡す |
+| `variant-genomic-context` | SPARQList / JBrowse | `/api/variant_summary`, JBrowse URL | SPARQList endpoint へ `variant` を渡し、取得した座標で JBrowse を表示する |
+| `variant-header` | TogoVar検索API / SPARQList | `/api/search/variant`, `/api/tgv2rs` | TogoVar検索APIで `tgv_id` に解決してから、`tgv_id` だけを `tgv2rs` に渡す |
+| `variant-links` | TogoVar検索API / SPARQList | `/api/search/variant`, `/api/variant_mogplus` | TogoVar検索APIで外部リンクを取得する。MoG+ は GRCh38 の場合だけ SPARQList へ問い合わせる |
+| `variant-mgend` | TogoVar検索API | `/api/search/variant` | TogoVar検索APIで `tgv_id` または location 検索から該当variantを取得する |
+| `variant-other-overlapping-variants` | SPARQList | `/api/variant_other_alternative_alleles` | SPARQList endpoint へ `variant` を渡し、入力variant自身は表示から除外する |
+| `variant-publication` | TogoVar検索API / SPARQList | `/api/search/variant`, `/api/tgv2rs`, `/api/variant_publication` | TogoVar検索APIで `tgv_id` に解決し、`tgv2rs` で RefSNP ID を取得してから文献を取得する |
+| `variant-summary` | SPARQList | `/api/variant_summary` | SPARQList endpoint へ `variant` を渡す。正常な空結果は値欄を空欄表示にする |
+| `variant-transcript` | SPARQList | `/api/variant_transcript` | SPARQList endpoint へ `variant` を渡す |
+
+補足:
+
+- TogoVar検索APIを使うstanzaの `data-url` は、TogoVar API base URL または `/api/search/variant` endpoint のどちらを指定しても動くように正規化しています。
+- `tgv_id` と `variant` の両方が指定された場合は、全体方針として `tgv_id` を優先します。
+- SPARQListを使うstanzaで `variant` を指定する場合は、対応するSPARQList endpoint 側も `variant` を解決できる必要があります。
 
 ## このリポジトリのブランチ運用
 

--- a/lib/sparqlist.ts
+++ b/lib/sparqlist.ts
@@ -5,19 +5,26 @@ import type { SparqlistStanzaParams } from "./types";
 /**
  * SPARQList の API エンドポイント URL を組み立てる。
  * sparqlist が未指定の場合は throw する(暗黙のフォールバックだと埋め込み側の設定ミスに気づきにくいため)。
- * URLSearchParams で tgv_id をエスケープする。
+ * URLSearchParams で tgv_id と追加パラメータをエスケープする。
  */
 export const buildSparqlistApiUrl = (
   endpoint: string,
   { sparqlist, tgv_id }: SparqlistStanzaParams,
+  additionalParams: Record<string, string | undefined> = {},
 ): string => {
   if (!sparqlist) {
     throw new Error("sparqlist parameter is required");
   }
 
-  const queryString = new URLSearchParams({
+  const queryParams = new URLSearchParams({
     tgv_id: String(tgv_id ?? ""),
-  }).toString();
+  });
+  Object.entries(additionalParams).forEach(([key, value]) => {
+    if (value !== undefined) {
+      queryParams.set(key, value);
+    }
+  });
+  const queryString = queryParams.toString();
 
   const baseUrl = sparqlist.replace(/\/+$/, "");
 

--- a/lib/sparqlist.ts
+++ b/lib/sparqlist.ts
@@ -3,21 +3,16 @@ import { unwrapValueFromBinding } from "togostanza/utils";
 import type { SparqlistStanzaParams } from "./types";
 
 /**
- * SPARQList の API エンドポイント URL を組み立てる。
- * sparqlist が未指定の場合は throw する(暗黙のフォールバックだと埋め込み側の設定ミスに気づきにくいため)。
- * tgv_id と variant(VCF表記 CHROM-POS-REF-ALT) は、指定された値をそれぞれクエリに含める。
+ * tgv_id / variant(VCF表記 CHROM-POS-REF-ALT) と追加パラメータから、
+ * 空文字/未指定の項目を除いたクエリ文字列を組み立てる。
  * sparqlist側は tgv_id があればそれを優先し、無ければ variant で解決する(どちらも無ければエラー)。
- * URLSearchParams で値と追加パラメータをエスケープする。
+ * sparqlist を必須化していないstanza(フォールバックURL方式)からも共通で使うため、
+ * URL全体の組み立て(buildSparqlistApiUrl)とは切り離してある。
  */
-export const buildSparqlistApiUrl = (
-  endpoint: string,
-  { sparqlist, tgv_id, variant }: SparqlistStanzaParams,
+export const buildIdentifierQueryString = (
+  { tgv_id, variant }: Pick<SparqlistStanzaParams, "tgv_id" | "variant">,
   additionalParams: Record<string, string | undefined> = {},
 ): string => {
-  if (!sparqlist) {
-    throw new Error("sparqlist parameter is required");
-  }
-
   const queryParams = new URLSearchParams();
   Object.entries({ tgv_id, variant, ...additionalParams }).forEach(
     ([key, value]) => {
@@ -26,9 +21,26 @@ export const buildSparqlistApiUrl = (
       }
     },
   );
-  const queryString = queryParams.toString();
 
-  const baseUrl = sparqlist.replace(/\/+$/, "");
+  return queryParams.toString();
+};
+
+/**
+ * SPARQList の API エンドポイント URL を組み立てる。
+ * sparqlist が未指定の場合は throw する(暗黙のフォールバックだと埋め込み側の設定ミスに気づきにくいため)。
+ * URLSearchParams で値と追加パラメータをエスケープする。
+ */
+export const buildSparqlistApiUrl = (
+  endpoint: string,
+  params: SparqlistStanzaParams,
+  additionalParams: Record<string, string | undefined> = {},
+): string => {
+  if (!params.sparqlist) {
+    throw new Error("sparqlist parameter is required");
+  }
+
+  const queryString = buildIdentifierQueryString(params, additionalParams);
+  const baseUrl = params.sparqlist.replace(/\/+$/, "");
 
   return `${baseUrl}/api/${endpoint}?${queryString}`;
 };

--- a/lib/sparqlist.ts
+++ b/lib/sparqlist.ts
@@ -5,11 +5,13 @@ import type { SparqlistStanzaParams } from "./types";
 /**
  * SPARQList の API エンドポイント URL を組み立てる。
  * sparqlist が未指定の場合は throw する(暗黙のフォールバックだと埋め込み側の設定ミスに気づきにくいため)。
- * URLSearchParams で tgv_id と追加パラメータをエスケープする。
+ * tgv_id と variant(VCF表記 CHROM-POS-REF-ALT) を両方クエリに含める。
+ * sparqlist側は tgv_id があればそれを優先し、無ければ variant で解決する(どちらも無ければエラー)。
+ * URLSearchParams で値と追加パラメータをエスケープする。
  */
 export const buildSparqlistApiUrl = (
   endpoint: string,
-  { sparqlist, tgv_id }: SparqlistStanzaParams,
+  { sparqlist, tgv_id, variant }: SparqlistStanzaParams,
   additionalParams: Record<string, string | undefined> = {},
 ): string => {
   if (!sparqlist) {
@@ -18,6 +20,7 @@ export const buildSparqlistApiUrl = (
 
   const queryParams = new URLSearchParams({
     tgv_id: String(tgv_id ?? ""),
+    variant: String(variant ?? ""),
   });
   Object.entries(additionalParams).forEach(([key, value]) => {
     if (value !== undefined) {
@@ -30,6 +33,15 @@ export const buildSparqlistApiUrl = (
 
   return `${baseUrl}/api/${endpoint}?${queryString}`;
 };
+
+/**
+ * エラーメッセージ表示用に、tgv_id / variant のうち指定されている方の識別子を返す。
+ * どちらも無い場合は空文字を返す。
+ */
+export const describeVariantIdentifier = ({
+  tgv_id,
+  variant,
+}: SparqlistStanzaParams): string => tgv_id || variant || "";
 
 /**
  * SPARQList エンドポイントから SPARQL バインディングを取得し、

--- a/lib/sparqlist.ts
+++ b/lib/sparqlist.ts
@@ -5,7 +5,7 @@ import type { SparqlistStanzaParams } from "./types";
 /**
  * SPARQList の API エンドポイント URL を組み立てる。
  * sparqlist が未指定の場合は throw する(暗黙のフォールバックだと埋め込み側の設定ミスに気づきにくいため)。
- * tgv_id と variant(VCF表記 CHROM-POS-REF-ALT) を両方クエリに含める。
+ * tgv_id と variant(VCF表記 CHROM-POS-REF-ALT) は、指定された値をそれぞれクエリに含める。
  * sparqlist側は tgv_id があればそれを優先し、無ければ variant で解決する(どちらも無ければエラー)。
  * URLSearchParams で値と追加パラメータをエスケープする。
  */
@@ -18,15 +18,14 @@ export const buildSparqlistApiUrl = (
     throw new Error("sparqlist parameter is required");
   }
 
-  const queryParams = new URLSearchParams({
-    tgv_id: String(tgv_id ?? ""),
-    variant: String(variant ?? ""),
-  });
-  Object.entries(additionalParams).forEach(([key, value]) => {
-    if (value !== undefined) {
-      queryParams.set(key, value);
-    }
-  });
+  const queryParams = new URLSearchParams();
+  Object.entries({ tgv_id, variant, ...additionalParams }).forEach(
+    ([key, value]) => {
+      if (value !== undefined && value !== "") {
+        queryParams.set(key, value);
+      }
+    },
+  );
   const queryString = queryParams.toString();
 
   const baseUrl = sparqlist.replace(/\/+$/, "");

--- a/lib/togovar-variant.ts
+++ b/lib/togovar-variant.ts
@@ -85,3 +85,16 @@ export const requireVariantData = (
 
   return variantData;
 };
+
+export const fetchVariantDataByIdentifier = async (
+  dataUrl: string,
+  tgvId: string | undefined,
+  parsedVariant: ParsedVariant | undefined,
+  identifier: string,
+): Promise<VariantData> => {
+  const apiResponse = tgvId
+    ? await fetchVariantDataById(dataUrl, tgvId)
+    : await fetchVariantDataByLocation(dataUrl, parsedVariant as ParsedVariant);
+
+  return requireVariantData(apiResponse, tgvId, parsedVariant, identifier);
+};

--- a/lib/togovar-variant.ts
+++ b/lib/togovar-variant.ts
@@ -3,6 +3,13 @@ import { normalizeChromosome } from "@/lib/variant";
 import type { TogoVarApiResponse, VariantData } from "./types";
 
 const LOCATION_QUERY_LIMIT = 1000;
+const VARIANT_SEARCH_API_PATH = "/api/search/variant";
+
+export const normalizeTogoVarApiBaseUrl = (dataUrl: string): string =>
+  dataUrl.replace(/\/+$/, "").replace(/\/api\/search\/variant$/i, "");
+
+export const buildVariantSearchApiUrl = (dataUrl: string): string =>
+  `${normalizeTogoVarApiBaseUrl(dataUrl)}${VARIANT_SEARCH_API_PATH}`;
 
 const sameVariantAllele = (
   variantData: VariantData,
@@ -19,7 +26,8 @@ export const postVariantQuery = async (
   query: Record<string, unknown>,
   options: Record<string, unknown> = {},
 ): Promise<TogoVarApiResponse> => {
-  const response = await fetch(dataUrl, {
+  const apiUrl = buildVariantSearchApiUrl(dataUrl);
+  const response = await fetch(apiUrl, {
     method: "POST",
     headers: {
       Accept: "application/json",
@@ -29,7 +37,7 @@ export const postVariantQuery = async (
   });
 
   if (!response.ok) {
-    throw new Error(`${dataUrl} returned status ${response.status}`);
+    throw new Error(`${apiUrl} returned status ${response.status}`);
   }
 
   return response.json() as Promise<TogoVarApiResponse>;

--- a/lib/togovar-variant.ts
+++ b/lib/togovar-variant.ts
@@ -5,12 +5,21 @@ import type { TogoVarApiResponse, VariantData } from "./types";
 const LOCATION_QUERY_LIMIT = 1000;
 const VARIANT_SEARCH_API_PATH = "/api/search/variant";
 
+/**
+ * stanzaごとに data-url の既存運用が揺れているため、base URL と
+ * `/api/search/variant` endpoint のどちらを受け取っても同じ検索APIへ正規化する。
+ */
 export const normalizeTogoVarApiBaseUrl = (dataUrl: string): string =>
   dataUrl.replace(/\/+$/, "").replace(/\/api\/search\/variant$/i, "");
 
+/** TogoVar variant search API の endpoint URL を組み立てる。 */
 export const buildVariantSearchApiUrl = (dataUrl: string): string =>
   `${normalizeTogoVarApiBaseUrl(dataUrl)}${VARIANT_SEARCH_API_PATH}`;
 
+/**
+ * location クエリは同一座標の複数アリルを返し得るため、
+ * chromosome/position だけで取得した候補を Ref/Alt で厳密に絞り込む。
+ */
 const sameVariantAllele = (
   variantData: VariantData,
   parsedVariant: ParsedVariant,
@@ -21,6 +30,10 @@ const sameVariantAllele = (
   String(variantData.reference).toUpperCase() === parsedVariant.reference &&
   String(variantData.alternate).toUpperCase() === parsedVariant.alternate;
 
+/**
+ * variant search API へPOSTする低レベル helper。
+ * 呼び出し元が base URL / endpoint のどちらを渡してもここで endpoint に正規化する。
+ */
 export const postVariantQuery = async (
   dataUrl: string,
   query: Record<string, unknown>,
@@ -43,6 +56,7 @@ export const postVariantQuery = async (
   return response.json() as Promise<TogoVarApiResponse>;
 };
 
+/** TogoVar ID で variant search API を検索する。 */
 export const fetchVariantDataById = (
   dataUrl: string,
   tgvId: string,
@@ -51,6 +65,7 @@ export const fetchVariantDataById = (
 /**
  * TogoVar検索APIは variant 表記そのものでの検索に対応していないため、
  * location で候補を広めに取得し、呼び出し側で Ref/Alt を照合する。
+ * multi-allelic site で候補を落とさないよう、通常の一覧表示より広めに取得する。
  */
 export const fetchVariantDataByLocation = (
   dataUrl: string,
@@ -73,6 +88,7 @@ export const fetchVariantDataByLocation = (
 /**
  * tgv_id 指定時は検索結果の先頭を採用する。
  * variant 指定時は location クエリの候補から Ref/Alt が一致するものだけを採用する。
+ * tgv_id と variant が両方ある場合は、SPARQList側の解決方針と同じく tgv_id を優先する。
  */
 export const requireVariantData = (
   apiResponse: TogoVarApiResponse,
@@ -94,6 +110,10 @@ export const requireVariantData = (
   return variantData;
 };
 
+/**
+ * stanza側の代表的な入口。tgv_id があればID検索、なければ parsedVariant の
+ * location検索へ切り替え、最終的に1件の VariantData として返す。
+ */
 export const fetchVariantDataByIdentifier = async (
   dataUrl: string,
   tgvId: string | undefined,

--- a/lib/togovar-variant.ts
+++ b/lib/togovar-variant.ts
@@ -1,0 +1,87 @@
+import type { ParsedVariant } from "@/lib/variant";
+import { normalizeChromosome } from "@/lib/variant";
+import type { TogoVarApiResponse, VariantData } from "./types";
+
+const LOCATION_QUERY_LIMIT = 1000;
+
+const sameVariantAllele = (
+  variantData: VariantData,
+  parsedVariant: ParsedVariant,
+): boolean =>
+  normalizeChromosome(variantData.chromosome) ===
+    normalizeChromosome(parsedVariant.chromosome) &&
+  String(variantData.position) === parsedVariant.position &&
+  String(variantData.reference).toUpperCase() === parsedVariant.reference &&
+  String(variantData.alternate).toUpperCase() === parsedVariant.alternate;
+
+export const postVariantQuery = async (
+  dataUrl: string,
+  query: Record<string, unknown>,
+  options: Record<string, unknown> = {},
+): Promise<TogoVarApiResponse> => {
+  const response = await fetch(dataUrl, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ ...options, query }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${dataUrl} returned status ${response.status}`);
+  }
+
+  return response.json() as Promise<TogoVarApiResponse>;
+};
+
+export const fetchVariantDataById = (
+  dataUrl: string,
+  tgvId: string,
+): Promise<TogoVarApiResponse> => postVariantQuery(dataUrl, { id: [tgvId] });
+
+/**
+ * TogoVar検索APIは variant 表記そのものでの検索に対応していないため、
+ * location で候補を広めに取得し、呼び出し側で Ref/Alt を照合する。
+ */
+export const fetchVariantDataByLocation = (
+  dataUrl: string,
+  parsedVariant: ParsedVariant,
+): Promise<TogoVarApiResponse> =>
+  postVariantQuery(
+    dataUrl,
+    {
+      location: {
+        chromosome: normalizeChromosome(parsedVariant.chromosome),
+        position: Number(parsedVariant.position),
+      },
+    },
+    {
+      offset: 0,
+      limit: LOCATION_QUERY_LIMIT,
+    },
+  );
+
+/**
+ * tgv_id 指定時は検索結果の先頭を採用する。
+ * variant 指定時は location クエリの候補から Ref/Alt が一致するものだけを採用する。
+ */
+export const requireVariantData = (
+  apiResponse: TogoVarApiResponse,
+  tgvId: string | undefined,
+  parsedVariant: ParsedVariant | undefined,
+  identifier: string,
+): VariantData => {
+  const variantData = tgvId
+    ? apiResponse.data[0]
+    : apiResponse.data.find(
+        (data) =>
+          parsedVariant !== undefined && sameVariantAllele(data, parsedVariant),
+      );
+
+  if (!variantData) {
+    throw new Error(`Variant not found for ${identifier}`);
+  }
+
+  return variantData;
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,7 +46,7 @@ export interface ExternalLinks {
   gnomad?: ExternalLink[];
   tommo?: ExternalLink[];
   jogo?: ExternalLink[];
-  sscvdb?: ExternalLink[];
+  sscv_db?: ExternalLink[];
   mog?: ExternalLink[];
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -53,6 +53,10 @@ export interface ExternalLinks {
 /** バリアントごとのデータ（有意性情報と外部リンクを含む） */
 export interface VariantData {
   id: string;
+  chromosome: string;
+  position: number;
+  reference: string;
+  alternate: string;
   significance: SignificanceEntry[];
   // 実際のTogoVar variant APIレスポンス（variant-mgendが叩くエンドポイント）で
   // 動作確認済みのフィールド名。gene-mgend/disease-mgend側のJS実装は

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -53,7 +53,6 @@ export interface ExternalLinks {
   tommo?: ExternalLink[];
   jogo?: ExternalLink[];
   sscv_db?: ExternalLink[];
-  mog?: ExternalLink[];
 }
 
 /** バリアントごとのデータ（有意性情報と外部リンクを含む） */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -44,6 +44,10 @@ export interface ExternalLinks {
   clinvar?: ExternalLink[];
   dbsnp?: ExternalLink[];
   gnomad?: ExternalLink[];
+  tommo?: ExternalLink[];
+  jogo?: ExternalLink[];
+  sscvdb?: ExternalLink[];
+  mog?: ExternalLink[];
 }
 
 /** バリアントごとのデータ（有意性情報と外部リンクを含む） */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,10 +3,16 @@
 // variant-mgend / disease-mgend / gene-mgend 等で共有する
 // ============================================================
 
-/** SPARQList を叩く stanza が共通して受け取る入力パラメータ。 */
+/**
+ * SPARQList を叩く stanza が共通して受け取る入力パラメータ。
+ * tgv_id を持たないバリアント（TogoVar未登録のバリアント）を表示するため、
+ * tgv_id の代わりに VCF表記(CHROM-POS-REF-ALT)の variant でも解決できる。
+ * どちらかが必須で、両方指定された場合は tgv_id を優先する（sparqlist側の解決ロジックと合わせる）。
+ */
 export interface SparqlistStanzaParams {
   sparqlist?: string;
   tgv_id?: string;
+  variant?: string;
 }
 
 /** SPARQList を叩く stanza が renderTemplate へ渡す共通パラメータ形。エラー時は result を持たない。 */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -67,7 +67,7 @@ export interface VariantData {
   // 動作確認済みのフィールド名。gene-mgend/disease-mgend側のJS実装は
   // external_link（単数形）を参照しているが、別エンドポイントのレスポンス形状であり、
   // ここを単数形に変更するとvariant-mgendでリンクが取得できなくなる。
-  external_links: ExternalLinks;
+  external_links?: ExternalLinks;
 }
 
 /** TogoVar API レスポンスのトップレベル構造 */

--- a/lib/variant.ts
+++ b/lib/variant.ts
@@ -49,3 +49,21 @@ export const parseVariantParam = (
 export const normalizeChromosome = (
   chromosome: string | undefined,
 ): string => String(chromosome ?? "").replace(/^chr/i, "").toUpperCase();
+
+export const assertValidVariantIdentifier = (
+  tgvId: string | undefined,
+  variant: string | undefined,
+  parsedVariant: ParsedVariant | undefined,
+): void => {
+  if (tgvId) {
+    return;
+  }
+
+  if (!variant) {
+    throw new Error("tgv_id or variant parameter is required");
+  }
+
+  if (!parsedVariant) {
+    throw new Error("variant parameter must use CHROM-POS-REF-ALT notation");
+  }
+};

--- a/lib/variant.ts
+++ b/lib/variant.ts
@@ -1,7 +1,7 @@
 // ============================================================
 // variant パラメータ(VCF表記 CHROM-POS-REF-ALT)共通処理
-// tgv_id を持たないバリアント（TogoVar未登録）を chromosome/position/reference/alternate
-// で解決するために、複数stanza(variant-other-overlapping-variants, variant-links)から使う。
+// tgv_id を持たないバリアント（TogoVar未登録）を扱うため、
+// VCF表記の variant パラメータを複数の variant 系stanzaで共通利用する。
 // ============================================================
 
 /** variant パラメータを分解した結果。 */

--- a/lib/variant.ts
+++ b/lib/variant.ts
@@ -50,6 +50,10 @@ export const normalizeChromosome = (
   chromosome: string | undefined,
 ): string => String(chromosome ?? "").replace(/^chr/i, "").toUpperCase();
 
+/**
+ * tgv_id が無い場合に variant の有無と形式を検証する。
+ * 未指定と malformed を分けて、ユーザーが入力ミスを直しやすいエラーにする。
+ */
 export const assertValidVariantIdentifier = (
   tgvId: string | undefined,
   variant: string | undefined,

--- a/lib/variant.ts
+++ b/lib/variant.ts
@@ -1,0 +1,37 @@
+// ============================================================
+// variant パラメータ(VCF表記 CHROM-POS-REF-ALT)共通処理
+// tgv_id を持たないバリアント（TogoVar未登録）を chromosome/position/reference/alternate
+// で解決するために、複数stanza(variant-other-overlapping-variants, variant-links)から使う。
+// ============================================================
+
+/** variant パラメータを分解した結果。 */
+export interface ParsedVariant {
+  chromosome: string;
+  position: string;
+  reference: string;
+  alternate: string;
+}
+
+/**
+ * variant パラメータ(例: "1-12345-A-T")を CHROM/POS/REF/ALT に分解する。
+ * ハイフン区切りが4要素ぴったりでない(いずれかが空になる)場合は解決不能とみなし undefined を返す。
+ */
+export const parseVariantParam = (
+  variant: string | undefined,
+): ParsedVariant | undefined => {
+  if (!variant) {
+    return undefined;
+  }
+
+  const [chromosome, position, reference, alternate] = variant.split("-");
+  if (!chromosome || !position || !reference || !alternate) {
+    return undefined;
+  }
+
+  return { chromosome, position, reference, alternate };
+};
+
+/** "chr1" と "1" のような表記揺れを吸収するため、先頭の "chr" プレフィックスを取り除く。 */
+export const normalizeChromosome = (
+  chromosome: string | undefined,
+): string => String(chromosome ?? "").replace(/^chr/i, "");

--- a/lib/variant.ts
+++ b/lib/variant.ts
@@ -23,15 +23,29 @@ export const parseVariantParam = (
     return undefined;
   }
 
-  const [chromosome, position, reference, alternate] = variant.split("-");
+  const parts = variant.split("-");
+  if (parts.length !== 4) {
+    return undefined;
+  }
+
+  const [chromosome, position, reference, alternate] = parts;
   if (!chromosome || !position || !reference || !alternate) {
     return undefined;
   }
 
-  return { chromosome, position, reference, alternate };
+  if (!Number.isFinite(Number(position))) {
+    return undefined;
+  }
+
+  return {
+    chromosome,
+    position,
+    reference: reference.toUpperCase(),
+    alternate: alternate.toUpperCase(),
+  };
 };
 
 /** "chr1" と "1" のような表記揺れを吸収するため、先頭の "chr" プレフィックスを取り除く。 */
 export const normalizeChromosome = (
   chromosome: string | undefined,
-): string => String(chromosome ?? "").replace(/^chr/i, "");
+): string => String(chromosome ?? "").replace(/^chr/i, "").toUpperCase();

--- a/stanzas/variant-clinvar/metadata.json
+++ b/stanzas/variant-clinvar/metadata.json
@@ -13,13 +13,19 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-04-22",
-  "stanza:updated": "2026-07-06",
+  "stanza:updated": "2026-07-27",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv219804",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "sparqlist",

--- a/stanzas/variant-frequency/README.md
+++ b/stanzas/variant-frequency/README.md
@@ -9,7 +9,7 @@
 | `tgv_id` | No | `tgv66359566` | TogoVar ID。`variant` が無い場合に必要です。 |
 | `variant` | No | `1-12345-A-T` | VCF表記 `CHROM-POS-REF-ALT` のバリアント。`tgv_id` が無い場合に使えます。 |
 | `assembly` | Yes | `GRCh38` | Assembly。`GRCh37` または `GRCh38`。 |
-| `data-url` | Yes | `https://stg-grch38.togovar.org` | TogoVar API base URL。 |
+| `data-url` | Yes | `https://stg-grch38.togovar.org` | TogoVar API base URL。頻度取得は `/search`、`variant` から TogoVar ID への解決は `/api/search/variant` を使います。 |
 | `no_data_message` | No | `No data found.` | データが無い場合の表示メッセージ。 |
 | `check_local_auth_status` | No | `true` | localhost でもログイン状態を確認する場合は `true`。 |
 

--- a/stanzas/variant-frequency/README.md
+++ b/stanzas/variant-frequency/README.md
@@ -9,7 +9,7 @@
 | `tgv_id` | No | `tgv66359566` | TogoVar ID。`variant` が無い場合に必要です。 |
 | `variant` | No | `1-12345-A-T` | VCF表記 `CHROM-POS-REF-ALT` のバリアント。`tgv_id` が無い場合に使えます。 |
 | `assembly` | Yes | `GRCh38` | Assembly。`GRCh37` または `GRCh38`。 |
-| `data-url` | Yes | `https://stg-grch38.togovar.org` | TogoVar API base URL。頻度取得は `/search`、`variant` から TogoVar ID への解決は `/api/search/variant` を使います。 |
+| `data-url` | Yes | `https://stg-grch38.togovar.org` | TogoVar API base URL。`/api/search/variant` endpoint を指定しても base URL へ正規化します。頻度取得は `/search`、`variant` から TogoVar ID への解決は `/api/search/variant` を使います。 |
 | `no_data_message` | No | `No data found.` | データが無い場合の表示メッセージ。 |
 | `check_local_auth_status` | No | `true` | localhost でもログイン状態を確認する場合は `true`。 |
 

--- a/stanzas/variant-frequency/README.md
+++ b/stanzas/variant-frequency/README.md
@@ -1,3 +1,16 @@
 # Variant / Frequency
 
-Stanza description goes here. Edit `stanzas/variant-frequency/README.md` to update.
+指定したバリアントのデータセット別アリル頻度を表示する stanza です。
+
+## Parameters
+
+| Key | Required | Example | Description |
+| --- | --- | --- | --- |
+| `tgv_id` | No | `tgv66359566` | TogoVar ID。`variant` が無い場合に必要です。 |
+| `variant` | No | `1-12345-A-T` | VCF表記 `CHROM-POS-REF-ALT` のバリアント。`tgv_id` が無い場合に使えます。 |
+| `assembly` | Yes | `GRCh38` | Assembly。`GRCh37` または `GRCh38`。 |
+| `data-url` | Yes | `https://stg-grch38.togovar.org` | TogoVar API base URL。 |
+| `no_data_message` | No | `No data found.` | データが無い場合の表示メッセージ。 |
+| `check_local_auth_status` | No | `true` | localhost でもログイン状態を確認する場合は `true`。 |
+
+`tgv_id` と `variant` の両方が指定された場合は `tgv_id` を優先します。

--- a/stanzas/variant-frequency/README.md
+++ b/stanzas/variant-frequency/README.md
@@ -14,3 +14,4 @@
 | `check_local_auth_status` | No | `true` | localhost でもログイン状態を確認する場合は `true`。 |
 
 `tgv_id` と `variant` の両方が指定された場合は `tgv_id` を優先します。
+`variant` だけが指定された場合は TogoVar variant search API で該当バリアントを探し、TogoVar ID があればそれを `/search` の `term` に渡します。TogoVar未登録で TogoVar ID が無い場合でも、dbSNP の `rsID` が取得できれば `rsID` を `term` として頻度情報を取得します。TogoVar ID / rsID のどちらも無い場合は、variant search API の候補レコードに含まれる `frequencies` を使って表示します。

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -12,6 +12,9 @@ import {
   downloadJSONMenuItem,
   downloadTSVMenuItem,
 } from "togostanza-utils";
+import { describeVariantIdentifier } from "@/lib/sparqlist";
+import { fetchVariantDataByIdentifier } from "@/lib/togovar-variant";
+import { parseVariantParam } from "@/lib/variant";
 
 // ============================================================
 // 型定義
@@ -60,6 +63,14 @@ interface DataNode {
   value: string;
   label: string;
   children?: DataNode[];
+}
+
+interface VariantFrequencyParams {
+  "data-url"?: string;
+  assembly?: string;
+  tgv_id?: string;
+  variant?: string;
+  check_local_auth_status?: unknown;
 }
 
 const isTruthyParam = (value: unknown): boolean => {
@@ -123,21 +134,65 @@ export default class VariantFrequency extends Stanza {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     // ---- stanzaパラメータの取得 ----
-    // data-url: APIのベースURL, assembly: GRCh37/GRCh38, tgv_id: バリアントID
+    // data-url: APIのベースURL, assembly: GRCh37/GRCh38, tgv_id/variant: バリアント識別子
     const {
       "data-url": urlBase,
       assembly,
       tgv_id,
       check_local_auth_status,
-    } = this.params;
+    } = this.params as VariantFrequencyParams;
+    const params = this.params as VariantFrequencyParams;
+    const parsedVariant = parseVariantParam(params.variant);
+
+    if (!urlBase) {
+      this.data = [];
+      this.renderTemplate({
+        template: "stanza.html.hbs",
+        parameters: {
+          params: this.params,
+          error: { message: "data-url parameter is required" },
+        },
+      });
+      return;
+    }
+
+    const searchEndpoint = `${urlBase.replace(/\/+$/, "")}/search`;
+    let resolvedTgvId = tgv_id;
+    try {
+      if (!resolvedTgvId && !parsedVariant) {
+        throw new Error("tgv_id or variant parameter is required");
+      }
+
+      if (!resolvedTgvId) {
+        const variantData = await fetchVariantDataByIdentifier(
+          searchEndpoint,
+          resolvedTgvId,
+          parsedVariant,
+          describeVariantIdentifier(params),
+        );
+        resolvedTgvId = variantData.id;
+      }
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+
+      this.data = [];
+      this.renderTemplate({
+        template: "stanza.html.hbs",
+        parameters: {
+          params: this.params,
+          error: { message },
+        },
+      });
+      return;
+    }
 
     // バリアントIDでデータセット情報を展開して取得するAPIエンドポイント
     const searchParams = new URLSearchParams({
       quality: "0",
-      term: String(tgv_id),
+      term: String(resolvedTgvId),
     });
     searchParams.append("expand_dataset", "");
-    const dataURL = `${urlBase}/search?${searchParams.toString()}`;
+    const dataURL = `${searchEndpoint}?${searchParams.toString()}`;
 
     // ---- 変数の初期化 ----
 

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -18,6 +18,7 @@ import {
   normalizeTogoVarApiBaseUrl,
 } from "@/lib/togovar-variant";
 import { assertValidVariantIdentifier, parseVariantParam } from "@/lib/variant";
+import type { VariantData } from "@/lib/types";
 
 // ============================================================
 // 型定義
@@ -59,6 +60,11 @@ interface FrequencyData {
   has_hemizygote_marker?: boolean;
 }
 
+type FrequencyVariantData = VariantData & {
+  frequencies?: FrequencyData[];
+  existing_variations?: string[];
+};
+
 /** DATASETSの各ノード（ツリー構造）に ID・depth を付加したもの */
 interface DataNode {
   id: string;
@@ -90,6 +96,22 @@ const isTruthyParam = (value: unknown): boolean => {
 
 const isLocalhostHost = (hostname: string): boolean => {
   return hostname === "localhost" || hostname === "127.0.0.1";
+};
+
+const findDbsnpIdentifier = (variantData: VariantData): string | undefined =>
+  variantData.external_links?.dbsnp?.find((link) =>
+    /^rs\d+$/iu.test(link.title),
+  )?.title;
+
+const buildFrequencySearchTerm = (
+  variantData: VariantData,
+): string | undefined => {
+  if (variantData.id) {
+    return variantData.id;
+  }
+
+  // /search は rsID でも頻度情報を引けるため、TogoVar未登録のvariantではdbSNPリンクを代替キーにする。
+  return findDbsnpIdentifier(variantData);
 };
 
 // ============================================================
@@ -161,18 +183,24 @@ export default class VariantFrequency extends Stanza {
 
     const apiBase = normalizeTogoVarApiBaseUrl(urlBase);
     const frequencySearchEndpoint = `${apiBase}/search`;
-    let resolvedTgvId = tgv_id;
+    let frequencySearchTerm = tgv_id;
+    let resolvedVariantData: FrequencyVariantData | undefined;
     try {
-      assertValidVariantIdentifier(resolvedTgvId, params.variant, parsedVariant);
+      assertValidVariantIdentifier(
+        frequencySearchTerm,
+        params.variant,
+        parsedVariant,
+      );
 
-      if (!resolvedTgvId) {
+      if (!frequencySearchTerm) {
         const variantData = await fetchVariantDataByIdentifier(
           urlBase,
-          resolvedTgvId,
+          frequencySearchTerm,
           parsedVariant,
           describeVariantIdentifier(params),
         );
-        resolvedTgvId = variantData.id;
+        resolvedVariantData = variantData as FrequencyVariantData;
+        frequencySearchTerm = buildFrequencySearchTerm(variantData);
       }
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : String(e);
@@ -187,14 +215,6 @@ export default class VariantFrequency extends Stanza {
       });
       return;
     }
-
-    // バリアントIDでデータセット情報を展開して取得するAPIエンドポイント
-    const searchParams = new URLSearchParams({
-      quality: "0",
-      term: String(resolvedTgvId),
-    });
-    searchParams.append("expand_dataset", "");
-    const dataURL = `${frequencySearchEndpoint}?${searchParams.toString()}`;
 
     // ---- 変数の初期化 ----
 
@@ -257,16 +277,37 @@ export default class VariantFrequency extends Stanza {
     // ---- 頻度データの取得と処理 ----
 
     try {
-      const response = await fetch(dataURL, {
-        method: "GET",
-        headers: { Accept: "application/json" },
-      });
+      let responseDatasets: { data: FrequencyVariantData[] };
 
-      if (!response.ok) {
-        throw new Error(`${dataURL} returns status ${response.status}`);
+      if (frequencySearchTerm) {
+        // tgv_id または rsID がある場合は、従来通り /search でデータセット展開済みの頻度情報を取得する。
+        const searchParams = new URLSearchParams({
+          quality: "0",
+          term: frequencySearchTerm,
+        });
+        searchParams.append("expand_dataset", "");
+        const dataURL = `${frequencySearchEndpoint}?${searchParams.toString()}`;
+
+        const response = await fetch(dataURL, {
+          method: "GET",
+          headers: { Accept: "application/json" },
+        });
+
+        if (!response.ok) {
+          throw new Error(`${dataURL} returns status ${response.status}`);
+        }
+
+        responseDatasets = (await response.json()) as {
+          data: FrequencyVariantData[];
+        };
+      } else if (resolvedVariantData) {
+        // TogoVar ID / rsID を持たないvariantでも、variant search APIの候補レコードにfrequenciesが含まれる場合がある。
+        // その場合は /search?term=undefined へ進まず、解決済みレコード内の頻度情報をそのまま表示に使う。
+        responseDatasets = { data: [resolvedVariantData] };
+      } else {
+        responseDatasets = { data: [] };
       }
 
-      const responseDatasets = await response.json();
       // APIレスポンスからバリアントの頻度データ配列を取り出す
       const frequenciesDatasets: FrequencyData[] | undefined =
         responseDatasets.data[0]?.frequencies;

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -156,14 +156,16 @@ export default class VariantFrequency extends Stanza {
       return;
     }
 
-    const searchEndpoint = `${urlBase.replace(/\/+$/, "")}/search`;
+    const apiBase = urlBase.replace(/\/+$/, "");
+    const variantSearchEndpoint = `${apiBase}/api/search/variant`;
+    const frequencySearchEndpoint = `${apiBase}/search`;
     let resolvedTgvId = tgv_id;
     try {
       assertValidVariantIdentifier(resolvedTgvId, params.variant, parsedVariant);
 
       if (!resolvedTgvId) {
         const variantData = await fetchVariantDataByIdentifier(
-          searchEndpoint,
+          variantSearchEndpoint,
           resolvedTgvId,
           parsedVariant,
           describeVariantIdentifier(params),
@@ -190,7 +192,7 @@ export default class VariantFrequency extends Stanza {
       term: String(resolvedTgvId),
     });
     searchParams.append("expand_dataset", "");
-    const dataURL = `${searchEndpoint}?${searchParams.toString()}`;
+    const dataURL = `${frequencySearchEndpoint}?${searchParams.toString()}`;
 
     // ---- 変数の初期化 ----
 

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -14,7 +14,7 @@ import {
 } from "togostanza-utils";
 import { describeVariantIdentifier } from "@/lib/sparqlist";
 import { fetchVariantDataByIdentifier } from "@/lib/togovar-variant";
-import { parseVariantParam } from "@/lib/variant";
+import { assertValidVariantIdentifier, parseVariantParam } from "@/lib/variant";
 
 // ============================================================
 // 型定義
@@ -159,9 +159,7 @@ export default class VariantFrequency extends Stanza {
     const searchEndpoint = `${urlBase.replace(/\/+$/, "")}/search`;
     let resolvedTgvId = tgv_id;
     try {
-      if (!resolvedTgvId && !parsedVariant) {
-        throw new Error("tgv_id or variant parameter is required");
-      }
+      assertValidVariantIdentifier(resolvedTgvId, params.variant, parsedVariant);
 
       if (!resolvedTgvId) {
         const variantData = await fetchVariantDataByIdentifier(

--- a/stanzas/variant-frequency/index.ts
+++ b/stanzas/variant-frequency/index.ts
@@ -13,7 +13,10 @@ import {
   downloadTSVMenuItem,
 } from "togostanza-utils";
 import { describeVariantIdentifier } from "@/lib/sparqlist";
-import { fetchVariantDataByIdentifier } from "@/lib/togovar-variant";
+import {
+  fetchVariantDataByIdentifier,
+  normalizeTogoVarApiBaseUrl,
+} from "@/lib/togovar-variant";
 import { assertValidVariantIdentifier, parseVariantParam } from "@/lib/variant";
 
 // ============================================================
@@ -156,8 +159,7 @@ export default class VariantFrequency extends Stanza {
       return;
     }
 
-    const apiBase = urlBase.replace(/\/+$/, "");
-    const variantSearchEndpoint = `${apiBase}/api/search/variant`;
+    const apiBase = normalizeTogoVarApiBaseUrl(urlBase);
     const frequencySearchEndpoint = `${apiBase}/search`;
     let resolvedTgvId = tgv_id;
     try {
@@ -165,7 +167,7 @@ export default class VariantFrequency extends Stanza {
 
       if (!resolvedTgvId) {
         const variantData = await fetchVariantDataByIdentifier(
-          variantSearchEndpoint,
+          urlBase,
           resolvedTgvId,
           parsedVariant,
           describeVariantIdentifier(params),

--- a/stanzas/variant-frequency/metadata.json
+++ b/stanzas/variant-frequency/metadata.json
@@ -13,13 +13,19 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-04-22",
-  "stanza:updated": "2022-04-15",
+  "stanza:updated": "2026-08-13",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv66359566",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "assembly",

--- a/stanzas/variant-frequency/metadata.json
+++ b/stanzas/variant-frequency/metadata.json
@@ -36,7 +36,7 @@
     {
       "stanza:key": "data-url",
       "stanza:example": "https://stg-grch38.togovar.org",
-      "stanza:description": "URL",
+      "stanza:description": "TogoVar API base URL. A variant search API URL is normalized to its base URL.",
       "stanza:required": true
     },
     {

--- a/stanzas/variant-frequency/style.scss
+++ b/stanzas/variant-frequency/style.scss
@@ -18,6 +18,16 @@ main {
         background-color: white;
       }
     }
+
+    .variant-frequency-no-data {
+      position: sticky;
+      left: 0;
+      width: 100%;
+      padding: 14px 0 16px;
+      font-size: 14px;
+      color: var(--color-black);
+      text-align: center;
+    }
   }
 
   // 周波数詳細テーブル本体はこの stanza 専用
@@ -279,10 +289,6 @@ main {
             &[data-filter="PASS"] {
               color: var(--color-sign-safe);
             }
-          }
-
-          &.nodata-message {
-            text-align: center;
           }
         }
       }

--- a/stanzas/variant-frequency/templates/stanza.html.hbs
+++ b/stanzas/variant-frequency/templates/stanza.html.hbs
@@ -199,16 +199,14 @@
               <td class='quality'>{{quality}}</td>
             </tr>
           {{/each}}
-        {{else}}
-          <tr>
-            <td
-              colspan="{{#if ../hasHemizygote}}17{{else}}14{{/if}}"
-              class="nodata-message text-center"
-            >{{../params.no_data_message}}</td>
-          </tr>
         {{/if}}
       </tbody>
       </table>
+      {{#unless resultObject}}
+        <div class="variant-frequency-no-data">
+          {{#if ../params.no_data_message}}{{../params.no_data_message}}{{else}}No data{{/if}}
+        </div>
+      {{/unless}}
     </div>
   {{/with}}
 {{/with}}

--- a/stanzas/variant-frequency/templates/stanza.html.hbs
+++ b/stanzas/variant-frequency/templates/stanza.html.hbs
@@ -200,7 +200,12 @@
             </tr>
           {{/each}}
         {{else}}
-          <tr><td colspan="11" class="nodata-message">{{../params.no_data_message}}</td></tr>
+          <tr>
+            <td
+              colspan="{{#if ../hasHemizygote}}17{{else}}14{{/if}}"
+              class="nodata-message text-center"
+            >{{../params.no_data_message}}</td>
+          </tr>
         {{/if}}
       </tbody>
       </table>

--- a/stanzas/variant-gene/index.js
+++ b/stanzas/variant-gene/index.js
@@ -2,6 +2,7 @@ import Stanza from "togostanza/stanza";
 import {grouping, unwrapValueFromBinding} from "togostanza/utils";
 
 import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
+import {buildIdentifierQueryString} from "@/lib/sparqlist";
 
 export default class VariantGene extends Stanza {
   async render() {
@@ -9,10 +10,7 @@ export default class VariantGene extends Stanza {
 
     // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
     // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
-    const queryString = new URLSearchParams({
-      tgv_id: this.params?.tgv_id ?? "",
-      variant: this.params?.variant ?? "",
-    }).toString();
+    const queryString = buildIdentifierQueryString(this.params ?? {});
     const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_gene?${queryString}`);
 
     const r = await fetch(sparqlist, {

--- a/stanzas/variant-gene/index.js
+++ b/stanzas/variant-gene/index.js
@@ -7,7 +7,13 @@ export default class VariantGene extends Stanza {
   async render() {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
-    const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_gene?tgv_id=${this.params.tgv_id}`);
+    // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
+    // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
+    const queryString = new URLSearchParams({
+      tgv_id: this.params?.tgv_id ?? "",
+      variant: this.params?.variant ?? "",
+    }).toString();
+    const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_gene?${queryString}`);
 
     const r = await fetch(sparqlist, {
       method: "GET",

--- a/stanzas/variant-gene/metadata.json
+++ b/stanzas/variant-gene/metadata.json
@@ -13,13 +13,19 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-04-22",
-  "stanza:updated": "2022-04-15",
+  "stanza:updated": "2026-07-27",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv219804",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "sparqlist",

--- a/stanzas/variant-gene/style.scss
+++ b/stanzas/variant-gene/style.scss
@@ -1,17 +1,56 @@
 @use "@/assets/css/common";
 
 main {
-  .table.gene {
-    > tbody {
-      > tr {
-        > th {
-          width: 139px;
-          text-align: right;
-        }
+  .variant-gene-list {
+    display: grid;
+    grid-template-columns: 130px minmax(0, 1fr);
+    width: 100%;
+    margin: 0;
+    font-family: "Roboto Condensed", sans-serif;
 
-        > td {
-          padding-left: 13px;
+    dt,
+    dd {
+      display: flex;
+      align-items: center;
+      padding-top: 3px;
+      padding-bottom: 3px;
+      line-height: 1.2;
+      border-bottom: 1px solid var(--color-table-border);
+    }
+
+    dt {
+      padding-left: 10px;
+      font-size: 12px;
+      font-weight: bold;
+      color: var(--color-black);
+      white-space: nowrap;
+    }
+
+    dd {
+      padding-right: 10px;
+      padding-left: 12px;
+      margin: 0;
+      font-size: 14px;
+      color: var(--color-black);
+      overflow-wrap: anywhere;
+
+      a {
+        color: var(--color-key-dark2);
+
+        &:hover {
+          color: var(--color-key-dark1);
         }
+      }
+    }
+
+    .gene-values {
+      padding: 0;
+      margin: 0;
+      line-height: 1.2;
+      list-style: none;
+
+      li + li {
+        margin-top: 2px;
       }
     }
   }

--- a/stanzas/variant-gene/templates/stanza.html.hbs
+++ b/stanzas/variant-gene/templates/stanza.html.hbs
@@ -2,31 +2,27 @@
   <div class="alert alert-danger">{{message}}</div>
 {{else}}
   {{#with result}}
-    <table class="table gene">
-      <tr>
-        <th>HGNC/Approved name</th>
-        <td>{{approved_name}}</td>
-      </tr>
-      <tr>
-        <th>HGNC/Approved symbol</th>
-        <td>
-          <ul class="no-bullet">
-            {{#each symbol}}
-              <li><a href="{{href}}">{{value}}</a></li>
-            {{/each}}
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <th>HGNC/Alias name</th>
-        <td>
-          <ul class="no-bullet">
-            {{#each synonym}}
-              <li>{{this}}</li>
-            {{/each}}
-          </ul>
-        </td>
-      </tr>
-    </table>
+    <dl class="variant-gene-list">
+      <dt>HGNC/Approved name</dt>
+      <dd>{{approved_name}}</dd>
+
+      <dt>HGNC/Approved symbol</dt>
+      <dd>
+        <ul class="gene-values">
+          {{#each symbol}}
+            <li><a href="{{href}}">{{value}}</a></li>
+          {{/each}}
+        </ul>
+      </dd>
+
+      <dt>HGNC/Alias name</dt>
+      <dd>
+        <ul class="gene-values">
+          {{#each synonym}}
+            <li>{{this}}</li>
+          {{/each}}
+        </ul>
+      </dd>
+    </dl>
   {{/with}}
 {{/with}}

--- a/stanzas/variant-genomic-context/index.js
+++ b/stanzas/variant-genomic-context/index.js
@@ -2,16 +2,13 @@ import Stanza from "togostanza/stanza";
 import {unwrapValueFromBinding} from "togostanza/utils";
 
 import {referenceToChrAssembly} from "@/lib/display";
-import {requireFirstBinding} from "@/lib/sparqlist";
+import {buildIdentifierQueryString, describeVariantIdentifier, requireFirstBinding} from "@/lib/sparqlist";
 
 export default class VariantSummary extends Stanza {
   async render() {
     // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
     // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
-    const queryString = new URLSearchParams({
-      tgv_id: this.params?.tgv_id ?? "",
-      variant: this.params?.variant ?? "",
-    }).toString();
+    const queryString = buildIdentifierQueryString(this.params ?? {});
     const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_summary?${queryString}`);
 
     const r = await fetch(sparqlist, {
@@ -27,7 +24,7 @@ export default class VariantSummary extends Stanza {
     }).then(data => {
       const binding = requireFirstBinding(
         unwrapValueFromBinding(data),
-        `Failed to obtain genomic position for ${this.params.tgv_id || this.params.variant}`,
+        `Failed to obtain genomic position for ${describeVariantIdentifier(this.params ?? {})}`,
       );
 
       const { chr } = referenceToChrAssembly(binding.reference);

--- a/stanzas/variant-genomic-context/index.js
+++ b/stanzas/variant-genomic-context/index.js
@@ -6,7 +6,13 @@ import {requireFirstBinding} from "@/lib/sparqlist";
 
 export default class VariantSummary extends Stanza {
   async render() {
-    const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_summary?tgv_id=${this.params.tgv_id}`);
+    // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
+    // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
+    const queryString = new URLSearchParams({
+      tgv_id: this.params?.tgv_id ?? "",
+      variant: this.params?.variant ?? "",
+    }).toString();
+    const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_summary?${queryString}`);
 
     const r = await fetch(sparqlist, {
       method: "GET",
@@ -21,7 +27,7 @@ export default class VariantSummary extends Stanza {
     }).then(data => {
       const binding = requireFirstBinding(
         unwrapValueFromBinding(data),
-        `Failed to obtain genomic position for ${this.params.tgv_id}`,
+        `Failed to obtain genomic position for ${this.params.tgv_id || this.params.variant}`,
       );
 
       const { chr } = referenceToChrAssembly(binding.reference);

--- a/stanzas/variant-genomic-context/metadata.json
+++ b/stanzas/variant-genomic-context/metadata.json
@@ -13,13 +13,19 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2015-02-03",
-  "stanza:updated": "2022-04-15",
+  "stanza:updated": "2026-07-27",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv219804",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "assembly",

--- a/stanzas/variant-header/README.md
+++ b/stanzas/variant-header/README.md
@@ -1,3 +1,14 @@
 # Variant / Header
 
-Stanza description goes here. Edit `stanzas/variant-header/README.md` to update.
+指定したバリアントに紐づく RefSNP ID を表示する stanza です。
+
+## Parameters
+
+| Key | Required | Example | Description |
+| --- | --- | --- | --- |
+| `tgv_id` | No | `tgv219804` | TogoVar ID。`variant` が無い場合に必要です。 |
+| `variant` | No | `1-12345-A-T` | VCF表記 `CHROM-POS-REF-ALT` のバリアント。`tgv_id` が無い場合に使えます。 |
+| `sparqlist` | No | `https://grch38.togovar.org/sparqlist` | SPARQList URL。 |
+| `data-url` | No | `https://stg-grch38.togovar.org/api/search/variant` | `variant` のみ指定時に TogoVar ID へ解決するための TogoVar variant search API URL。 |
+
+`tgv_id` と `variant` の両方が指定された場合は `tgv_id` を優先します。

--- a/stanzas/variant-header/README.md
+++ b/stanzas/variant-header/README.md
@@ -9,6 +9,6 @@
 | `tgv_id` | No | `tgv219804` | TogoVar ID。`variant` が無い場合に必要です。 |
 | `variant` | No | `1-12345-A-T` | VCF表記 `CHROM-POS-REF-ALT` のバリアント。`tgv_id` が無い場合に使えます。 |
 | `sparqlist` | No | `https://grch38.togovar.org/sparqlist` | SPARQList URL。 |
-| `data-url` | No | `https://stg-grch38.togovar.org/api/search/variant` | `variant` のみ指定時に TogoVar ID へ解決するための TogoVar variant search API URL。 |
+| `data-url` | No | `https://stg-grch38.togovar.org/api/search/variant` | `variant` のみ指定時に TogoVar ID へ解決するための URL。TogoVar API base URL または `/api/search/variant` endpoint を指定できます。 |
 
 `tgv_id` と `variant` の両方が指定された場合は `tgv_id` を優先します。

--- a/stanzas/variant-header/index.js
+++ b/stanzas/variant-header/index.js
@@ -3,31 +3,56 @@ import {unwrapValueFromBinding} from "togostanza/utils";
 
 import uniq from "@/lib/uniq";
 import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
-import {buildIdentifierQueryString} from "@/lib/sparqlist";
+import {buildIdentifierQueryString, describeVariantIdentifier} from "@/lib/sparqlist";
+import {fetchVariantDataByIdentifier} from "@/lib/togovar-variant";
+import {parseVariantParam} from "@/lib/variant";
 
 export default class VariantHeader extends Stanza {
   async render() {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
-    // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
-    // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
-    const queryString = buildIdentifierQueryString(this.params);
-    const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?${queryString}`);
+    const params = this.params ?? {};
+    const parsedVariant = parseVariantParam(params.variant);
 
-    const r = await fetch(sparqlist, {
-      method: "GET",
-      headers: {
-        "Accept": "application/json",
-      },
+    const r = await Promise.resolve().then(async () => {
+      if (!params.tgv_id && !parsedVariant) {
+        throw new Error("tgv_id or variant parameter is required");
+      }
+
+      let tgvId = params.tgv_id;
+      if (!tgvId) {
+        if (!params["data-url"]) {
+          throw new Error("data-url parameter is required when variant is given without tgv_id");
+        }
+
+        const variantData = await fetchVariantDataByIdentifier(
+          params["data-url"],
+          tgvId,
+          parsedVariant,
+          describeVariantIdentifier(params),
+        );
+        tgvId = variantData.id;
+      }
+
+      // tgv2rs は variant を解釈しないため、必ず解決済みの tgv_id だけを渡す。
+      const queryString = buildIdentifierQueryString({ tgv_id: tgvId });
+      const sparqlist = (params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?${queryString}`);
+
+      return fetch(sparqlist, {
+        method: "GET",
+        headers: {
+          "Accept": "application/json",
+        },
+      });
     }).then(res => {
       if (res.ok) {
         return res.json();
       }
-      throw new Error(sparqlist + " returns status " + res.status);
+      throw new Error("tgv2rs returns status " + res.status);
     }).then(data => {
       const results = unwrapValueFromBinding(data);
 
-      if (!results) {
+      if (!results?.length) {
         return {result: {xrefs: {}}};
       }
 
@@ -36,7 +61,8 @@ export default class VariantHeader extends Stanza {
           xrefs: [
             {
               name: "RefSNP ID",
-              refs: uniq(results.map(x => x.rs)).map(x => ({label: x.split("/").slice(-1)[0], url: x})),
+              refs: uniq(results.map(x => x.rs).filter(x => x))
+                .map(x => ({label: x.split("/").slice(-1)[0], url: x})),
             },
           ],
         },

--- a/stanzas/variant-header/index.js
+++ b/stanzas/variant-header/index.js
@@ -8,7 +8,13 @@ export default class VariantHeader extends Stanza {
   async render() {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
-    const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?tgv_id=${this.params.tgv_id}`);
+    // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
+    // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
+    const queryString = new URLSearchParams({
+      tgv_id: this.params.tgv_id ?? "",
+      variant: this.params.variant ?? "",
+    }).toString();
+    const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?${queryString}`);
 
     const r = await fetch(sparqlist, {
       method: "GET",

--- a/stanzas/variant-header/index.js
+++ b/stanzas/variant-header/index.js
@@ -3,6 +3,7 @@ import {unwrapValueFromBinding} from "togostanza/utils";
 
 import uniq from "@/lib/uniq";
 import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
+import {buildIdentifierQueryString} from "@/lib/sparqlist";
 
 export default class VariantHeader extends Stanza {
   async render() {
@@ -10,10 +11,7 @@ export default class VariantHeader extends Stanza {
 
     // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
     // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
-    const queryString = new URLSearchParams({
-      tgv_id: this.params.tgv_id ?? "",
-      variant: this.params.variant ?? "",
-    }).toString();
+    const queryString = buildIdentifierQueryString(this.params);
     const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?${queryString}`);
 
     const r = await fetch(sparqlist, {

--- a/stanzas/variant-header/index.js
+++ b/stanzas/variant-header/index.js
@@ -5,7 +5,7 @@ import uniq from "@/lib/uniq";
 import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
 import {buildIdentifierQueryString, describeVariantIdentifier} from "@/lib/sparqlist";
 import {fetchVariantDataByIdentifier} from "@/lib/togovar-variant";
-import {parseVariantParam} from "@/lib/variant";
+import {assertValidVariantIdentifier, parseVariantParam} from "@/lib/variant";
 
 export default class VariantHeader extends Stanza {
   async render() {
@@ -15,9 +15,7 @@ export default class VariantHeader extends Stanza {
     const parsedVariant = parseVariantParam(params.variant);
 
     const r = await Promise.resolve().then(async () => {
-      if (!params.tgv_id && !parsedVariant) {
-        throw new Error("tgv_id or variant parameter is required");
-      }
+      assertValidVariantIdentifier(params.tgv_id, params.variant, parsedVariant);
 
       let tgvId = params.tgv_id;
       if (!tgvId) {

--- a/stanzas/variant-header/metadata.json
+++ b/stanzas/variant-header/metadata.json
@@ -13,13 +13,19 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-06-07",
-  "stanza:updated": "2022-04-15",
+  "stanza:updated": "2026-07-27",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv219804",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "sparqlist",

--- a/stanzas/variant-header/metadata.json
+++ b/stanzas/variant-header/metadata.json
@@ -13,7 +13,7 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-06-07",
-  "stanza:updated": "2026-07-27",
+  "stanza:updated": "2026-08-12",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
@@ -31,6 +31,12 @@
       "stanza:key": "sparqlist",
       "stanza:example": "https://grch38.togovar.org/sparqlist",
       "stanza:description": "SPARQList URL",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "data-url",
+      "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
+      "stanza:description": "TogoVar variant search API URL (required when variant is given without tgv_id)",
       "stanza:required": false
     }
   ],

--- a/stanzas/variant-header/metadata.json
+++ b/stanzas/variant-header/metadata.json
@@ -36,7 +36,7 @@
     {
       "stanza:key": "data-url",
       "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
-      "stanza:description": "TogoVar variant search API URL (required when variant is given without tgv_id)",
+      "stanza:description": "TogoVar API base URL or variant search API URL (required when variant is given without tgv_id)",
       "stanza:required": false
     }
   ],

--- a/stanzas/variant-links/README.md
+++ b/stanzas/variant-links/README.md
@@ -8,7 +8,7 @@
 | --- | --- | --- | --- |
 | `tgv_id` | No(`variant`未指定時は必須) | `tgv167913213` | TogoVar ID。 |
 | `variant` | No(`tgv_id`未指定時は必須) | `1-12345-A-T` | VCF表記(CHROM-POS-REF-ALT)のバリアント。TogoVar未登録で`tgv_id`を持たないバリアントを表示する場合に使う。両方指定時は`tgv_id`を優先する。 |
-| `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar variant search API URL。 |
+| `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar API base URL または `/api/search/variant` endpoint。 |
 | `assembly` | No | `GRCh38` | TogoVar variant 座標の assembly。MoG+ は GRCh38 の場合だけ問い合わせます。未指定時は `data-url` / `sparqlist` から `GRCh38`/`GRCh37` を推定します。 |
 | `sparqlist` | No | `https://stg-grch38.togovar.org/sparqlist` | MoG+ cross species link を取得するSPARQList URL。未指定時は MoG+ を `N/A` と表示します。 |
 | `mogplus_ver` | No | `mogplus21` | MoG+ version。未指定時は `mogplus21` を使います。 |

--- a/stanzas/variant-links/README.md
+++ b/stanzas/variant-links/README.md
@@ -6,22 +6,14 @@
 
 | Key | Required | Example | Description |
 | --- | --- | --- | --- |
-| `tgv_id` | No | `tgv167913213` | TogoVar ID。`variant` を指定しない場合に必要です。 |
-| `variant` | No | `12-111803962-G-A` | chr-pos-ref-alt形式のバリアント表記。`tgv_id` を指定しない場合に必要です。 |
-| `sparqlist` | Yes | `http://localhost:3000` | `variant_links` endpoint を持つSPARQList URL。 |
+| `tgv_id` | Yes | `tgv167913213` | TogoVar ID。 |
+| `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar variant search API URL。 |
 
-## Local SPARQList
+## Data Source
 
-本番の `https://grch38.togovar.org/sparqlist` に `variant_links` endpoint が未反映の場合は、
-ローカルで起動したSPARQListを指定してください。
+このstanzaは TogoVar variant search API の `external_links` を参照します。
 
 ```txt
-sparqlist=http://localhost:3000
 tgv_id=tgv167913213
-```
-
-この設定では、stanzaは次のAPIを参照します。
-
-```txt
-http://localhost:3000/api/variant_links?tgv_id=tgv167913213
+data-url=https://grch38.togovar.org/api/search/variant
 ```

--- a/stanzas/variant-links/README.md
+++ b/stanzas/variant-links/README.md
@@ -8,12 +8,17 @@
 | --- | --- | --- | --- |
 | `tgv_id` | Yes | `tgv167913213` | TogoVar ID。 |
 | `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar variant search API URL。 |
+| `sparqlist` | No | `https://stg-grch38.togovar.org/sparqlist` | MoG+ cross species link を取得するSPARQList URL。未指定時は MoG+ を `N/A` と表示します。 |
+| `mogplus_ver` | No | `mogplus21` | MoG+ version。未指定時は `mogplus21` を使います。 |
 
 ## Data Source
 
 このstanzaは TogoVar variant search API の `external_links` を参照します。
+MoG+ cross species は TogoVar API の `external_links` ではなく、
+SPARQList の `variant_mogplus` endpoint から取得します。
 
 ```txt
 tgv_id=tgv167913213
 data-url=https://grch38.togovar.org/api/search/variant
+sparqlist=https://grch38.togovar.org/sparqlist
 ```

--- a/stanzas/variant-links/README.md
+++ b/stanzas/variant-links/README.md
@@ -6,7 +6,8 @@
 
 | Key | Required | Example | Description |
 | --- | --- | --- | --- |
-| `tgv_id` | Yes | `tgv167913213` | TogoVar ID。 |
+| `tgv_id` | No(`variant`未指定時は必須) | `tgv167913213` | TogoVar ID。 |
+| `variant` | No(`tgv_id`未指定時は必須) | `1-12345-A-T` | VCF表記(CHROM-POS-REF-ALT)のバリアント。TogoVar未登録で`tgv_id`を持たないバリアントを表示する場合に使う。両方指定時は`tgv_id`を優先する。 |
 | `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar variant search API URL。 |
 | `sparqlist` | No | `https://stg-grch38.togovar.org/sparqlist` | MoG+ cross species link を取得するSPARQList URL。未指定時は MoG+ を `N/A` と表示します。 |
 | `mogplus_ver` | No | `mogplus21` | MoG+ version。未指定時は `mogplus21` を使います。 |
@@ -14,6 +15,11 @@
 ## Data Source
 
 このstanzaは TogoVar variant search API の `external_links` を参照します。
+`tgv_id` 指定時は `id` クエリで直接引けますが、`variant` 指定時は
+TogoVar検索APIが variant 表記そのものでの検索に対応していないため、
+`location`(chromosome/position) クエリで同じ位置の候補を取得し、
+reference/alternate が一致するものをこのstanza側で絞り込みます
+(multi-allelicサイトでは同じ位置に複数バリアントが存在するため)。
 MoG+ cross species は TogoVar API の `external_links` ではなく、
 SPARQList の `variant_mogplus` endpoint から取得します。
 

--- a/stanzas/variant-links/README.md
+++ b/stanzas/variant-links/README.md
@@ -9,6 +9,7 @@
 | `tgv_id` | No(`variant`未指定時は必須) | `tgv167913213` | TogoVar ID。 |
 | `variant` | No(`tgv_id`未指定時は必須) | `1-12345-A-T` | VCF表記(CHROM-POS-REF-ALT)のバリアント。TogoVar未登録で`tgv_id`を持たないバリアントを表示する場合に使う。両方指定時は`tgv_id`を優先する。 |
 | `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar variant search API URL。 |
+| `assembly` | No | `GRCh38` | TogoVar variant 座標の assembly。MoG+ は GRCh38 の場合だけ問い合わせます。未指定時は `data-url` / `sparqlist` から `GRCh38`/`GRCh37` を推定します。 |
 | `sparqlist` | No | `https://stg-grch38.togovar.org/sparqlist` | MoG+ cross species link を取得するSPARQList URL。未指定時は MoG+ を `N/A` と表示します。 |
 | `mogplus_ver` | No | `mogplus21` | MoG+ version。未指定時は `mogplus21` を使います。 |
 
@@ -21,7 +22,10 @@ TogoVar検索APIが variant 表記そのものでの検索に対応していな�
 reference/alternate が一致するものをこのstanza側で絞り込みます
 (multi-allelicサイトでは同じ位置に複数バリアントが存在するため)。
 MoG+ cross species は TogoVar API の `external_links` ではなく、
-SPARQList の `variant_mogplus` endpoint から取得します。
+SPARQList の `variant_mogplus` endpoint から取得します。`variant_mogplus` へ渡す
+座標は GRCh38 として扱われるため、`assembly` が `GRCh38` と解決できる場合だけ
+MoG+ を問い合わせます。`GRCh37` または assembly が解決できない場合は MoG+ を
+`N/A` と表示します。
 
 ```txt
 tgv_id=tgv167913213

--- a/stanzas/variant-links/README.md
+++ b/stanzas/variant-links/README.md
@@ -1,0 +1,3 @@
+# Variant links
+
+Stanza description goes here. Edit `stanzas/variant-links/README.md` to update.

--- a/stanzas/variant-links/README.md
+++ b/stanzas/variant-links/README.md
@@ -1,3 +1,27 @@
 # Variant links
 
-Stanza description goes here. Edit `stanzas/variant-links/README.md` to update.
+指定したバリアントに紐づく外部データベースリンクをカテゴリ別に表示するstanzaです。
+
+## Parameters
+
+| Key | Required | Example | Description |
+| --- | --- | --- | --- |
+| `tgv_id` | No | `tgv167913213` | TogoVar ID。`variant` を指定しない場合に必要です。 |
+| `variant` | No | `12-111803962-G-A` | chr-pos-ref-alt形式のバリアント表記。`tgv_id` を指定しない場合に必要です。 |
+| `sparqlist` | Yes | `http://localhost:3000` | `variant_links` endpoint を持つSPARQList URL。 |
+
+## Local SPARQList
+
+本番の `https://grch38.togovar.org/sparqlist` に `variant_links` endpoint が未反映の場合は、
+ローカルで起動したSPARQListを指定してください。
+
+```txt
+sparqlist=http://localhost:3000
+tgv_id=tgv167913213
+```
+
+この設定では、stanzaは次のAPIを参照します。
+
+```txt
+http://localhost:3000/api/variant_links?tgv_id=tgv167913213
+```

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -1,7 +1,7 @@
 import Stanza from "togostanza/stanza";
 
 import { ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
-import type { ExternalLink, TogoVarApiResponse } from "@/lib/types";
+import type { ExternalLink, TogoVarApiResponse, VariantData } from "@/lib/types";
 
 // ============================================================
 // 型定義
@@ -50,6 +50,8 @@ interface TemplateRenderParams {
 interface VariantLinksParams {
   tgv_id?: string;
   "data-url"?: string;
+  sparqlist?: string;
+  mogplus_ver?: string;
 }
 
 type ExternalLinkKey =
@@ -64,6 +66,19 @@ type ExternalLinkKey =
 
 type VariantExternalLinks = Partial<Record<ExternalLinkKey, ExternalLink[]>>;
 
+interface MogplusEntry {
+  target?: string;
+  chr?: string;
+  pos?: number;
+  ref?: string;
+  alt?: string;
+  strains?: string[];
+}
+
+const DEFAULT_MOGPLUS_VERSION = "mogplus21";
+const DEFAULT_MOGPLUS_SOURCE = "GRCh38";
+const MOGPLUS_BASE_URL = "https://molossinus.brc.riken.jp";
+
 const CATEGORY_LAYOUT = [
   ["Clinical significance", "Cross species"],
   ["Frequency", "Splicing variant"],
@@ -71,6 +86,7 @@ const CATEGORY_LAYOUT = [
 
 const CATEGORY_ANCHORS: Record<string, string> = {
   "Clinical significance": "#clinical-significance-mgend",
+  "Cross species": "#cross-species",
   Frequency: "#frequency",
 };
 
@@ -113,8 +129,113 @@ const firstExternalLink = (
   return externalLinks[key]?.[0];
 };
 
+const normalizeMogplusEntry = (json: unknown): MogplusEntry | undefined => {
+  if (Array.isArray(json)) {
+    return json[0] as MogplusEntry | undefined;
+  }
+  if (typeof json !== "object" || json === null) {
+    return undefined;
+  }
+
+  const response = json as { data?: unknown[]; error?: unknown; target?: string };
+  if (response.error) {
+    return undefined;
+  }
+  if (Array.isArray(response.data)) {
+    return response.data[0] as MogplusEntry | undefined;
+  }
+  if (response.target) {
+    return response as MogplusEntry;
+  }
+
+  return undefined;
+};
+
+const buildMogplusApiUrl = (
+  sparqlist: string,
+  variant: VariantData,
+  mogplusVersion: string,
+): string => {
+  const params = new URLSearchParams({
+    source: DEFAULT_MOGPLUS_SOURCE,
+    chr: variant.chromosome,
+    pos: String(variant.position),
+    ref: variant.reference,
+    alt: variant.alternate,
+    mogplus_ver: mogplusVersion,
+  });
+
+  return `${sparqlist.replace(/\/+$/, "")}/api/variant_mogplus?${params.toString()}`;
+};
+
+const buildMogplusSourceUrl = (
+  entry: MogplusEntry,
+  mogplusVersion: string,
+): string | undefined => {
+  if (!entry.chr || !entry.pos) {
+    return undefined;
+  }
+
+  const strains = Array.isArray(entry.strains) ? entry.strains : [];
+  const strainParams = ["refGenome"].concat(
+    strains.map((strain) => strain.replace(/\//g, "_")),
+  );
+  const query = [
+    strainParams
+      .map((strain) => `strainNoSlct=${encodeURIComponent(strain)}`)
+      .join("&"),
+    `chrName=${encodeURIComponent(entry.chr)}`,
+    `chrStart=${Number(entry.pos) - 500}`,
+    `chrEnd=${Number(entry.pos) + 500}`,
+    "seqType=genome",
+    `chrName=${encodeURIComponent(entry.chr)}`,
+    "geneNameSearchText=",
+    "index=submit",
+    "presentType=disp",
+  ].join("&");
+
+  return `${MOGPLUS_BASE_URL}/${mogplusVersion}/variantTable/?${query}`;
+};
+
+const buildMogplusSource = (
+  entry: MogplusEntry | undefined,
+  mogplusVersion: string,
+): LinkSource => ({
+  name: "MoG+ (Mouse)",
+  value:
+    entry?.chr && entry.pos && entry.ref && entry.alt
+      ? `${entry.chr}-${entry.pos}-${entry.ref}-${entry.alt}`
+      : undefined,
+  url: entry ? buildMogplusSourceUrl(entry, mogplusVersion) : undefined,
+  available: Boolean(entry),
+});
+
+const fetchMogplusEntry = async (
+  sparqlist: string | undefined,
+  variant: VariantData | undefined,
+  mogplusVersion: string,
+): Promise<MogplusEntry | undefined> => {
+  if (!sparqlist || !variant) {
+    return undefined;
+  }
+
+  const apiUrl = buildMogplusApiUrl(sparqlist, variant, mogplusVersion);
+  const response = await fetch(apiUrl, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`${apiUrl} returned status ${response.status}`);
+  }
+
+  return normalizeMogplusEntry(await response.json());
+};
+
 const buildLinkCategoryRows = (
   apiResponse: TogoVarApiResponse,
+  mogplusEntry: MogplusEntry | undefined,
+  mogplusVersion: string,
 ): LinkCategoryRow[] => {
   const externalLinks = (apiResponse.data[0]?.external_links ??
     {}) as VariantExternalLinks;
@@ -141,12 +262,8 @@ const buildLinkCategoryRows = (
       "Cross species",
       {
         label: "Cross species",
-        sources: [
-          buildSourceFromExternalLink(
-            "MoG+ (Mouse)",
-            firstExternalLink(externalLinks, "mog"),
-          ),
-        ],
+        anchor: CATEGORY_ANCHORS["Cross species"],
+        sources: [buildMogplusSource(mogplusEntry, mogplusVersion)],
       },
     ],
     [
@@ -230,7 +347,17 @@ export default class VariantLinks extends Stanza {
       }
 
       const apiResponse = await fetchVariantLinks(dataUrl, tgvId);
-      templateParams.result = buildLinkCategoryRows(apiResponse);
+      const mogplusVersion = params.mogplus_ver ?? DEFAULT_MOGPLUS_VERSION;
+      const mogplusEntry = await fetchMogplusEntry(
+        params.sparqlist,
+        apiResponse.data[0],
+        mogplusVersion,
+      );
+      templateParams.result = buildLinkCategoryRows(
+        apiResponse,
+        mogplusEntry,
+        mogplusVersion,
+      );
     } catch (reason) {
       console.error(reason);
       templateParams.error = {

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -133,13 +133,28 @@ const inferAssemblyFromUrl = (url: string | undefined): string | undefined => {
   return undefined;
 };
 
+const normalizeAssembly = (assembly: string | undefined): string | undefined => {
+  if (!assembly) {
+    return undefined;
+  }
+
+  if (/^grch38$/i.test(assembly)) {
+    return "GRCh38";
+  }
+  if (/^grch37$/i.test(assembly)) {
+    return "GRCh37";
+  }
+
+  return assembly;
+};
+
 const resolveAssembly = ({
   assembly,
   "data-url": dataUrl,
   sparqlist,
 }: VariantLinksParams): string | undefined => {
   if (assembly) {
-    return assembly;
+    return normalizeAssembly(assembly);
   }
 
   return inferAssemblyFromUrl(dataUrl) ?? inferAssemblyFromUrl(sparqlist);

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -58,6 +58,7 @@ interface TemplateRenderParams {
 interface VariantLinksParams {
   tgv_id?: string;
   variant?: string;
+  assembly?: string;
   "data-url"?: string;
   sparqlist?: string;
   mogplus_ver?: string;
@@ -84,7 +85,7 @@ interface MogplusEntry {
 }
 
 const DEFAULT_MOGPLUS_VERSION = "mogplus21";
-const DEFAULT_MOGPLUS_SOURCE = "GRCh38";
+const SUPPORTED_MOGPLUS_SOURCE = "GRCh38";
 const MOGPLUS_BASE_URL = "https://molossinus.brc.riken.jp";
 
 const CATEGORY_LAYOUT = [
@@ -117,6 +118,33 @@ const firstExternalLink = (
   return externalLinks[key]?.[0];
 };
 
+const inferAssemblyFromUrl = (url: string | undefined): string | undefined => {
+  if (!url) {
+    return undefined;
+  }
+
+  if (/grch38/i.test(url)) {
+    return "GRCh38";
+  }
+  if (/grch37/i.test(url)) {
+    return "GRCh37";
+  }
+
+  return undefined;
+};
+
+const resolveAssembly = ({
+  assembly,
+  "data-url": dataUrl,
+  sparqlist,
+}: VariantLinksParams): string | undefined => {
+  if (assembly) {
+    return assembly;
+  }
+
+  return inferAssemblyFromUrl(dataUrl) ?? inferAssemblyFromUrl(sparqlist);
+};
+
 const normalizeMogplusEntry = (json: unknown): MogplusEntry | undefined => {
   if (Array.isArray(json)) {
     return json[0] as MogplusEntry | undefined;
@@ -142,10 +170,11 @@ const normalizeMogplusEntry = (json: unknown): MogplusEntry | undefined => {
 const buildMogplusApiUrl = (
   sparqlist: string,
   variant: VariantData,
+  sourceAssembly: string,
   mogplusVersion: string,
 ): string => {
   const params = new URLSearchParams({
-    source: DEFAULT_MOGPLUS_SOURCE,
+    source: sourceAssembly,
     chr: variant.chromosome,
     pos: String(variant.position),
     ref: variant.reference,
@@ -200,14 +229,24 @@ const buildMogplusSource = (
 const fetchMogplusEntry = async (
   sparqlist: string | undefined,
   variant: VariantData | undefined,
+  sourceAssembly: string | undefined,
   mogplusVersion: string,
 ): Promise<MogplusEntry | undefined> => {
   if (!sparqlist || !variant) {
     return undefined;
   }
 
+  if (sourceAssembly !== SUPPORTED_MOGPLUS_SOURCE) {
+    return undefined;
+  }
+
   try {
-    const apiUrl = buildMogplusApiUrl(sparqlist, variant, mogplusVersion);
+    const apiUrl = buildMogplusApiUrl(
+      sparqlist,
+      variant,
+      sourceAssembly,
+      mogplusVersion,
+    );
     const response = await fetch(apiUrl, {
       method: "GET",
       headers: { Accept: "application/json" },
@@ -353,9 +392,11 @@ export default class VariantLinks extends Stanza {
         describeVariantIdentifier(params),
       );
       const mogplusVersion = params.mogplus_ver ?? DEFAULT_MOGPLUS_VERSION;
+      const sourceAssembly = resolveAssembly(params);
       const mogplusEntry = await fetchMogplusEntry(
         params.sparqlist,
         variantData,
+        sourceAssembly,
         mogplusVersion,
       );
       templateParams.result = buildLinkCategoryRows(

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -66,8 +66,7 @@ type VariantExternalLinks = Partial<Record<ExternalLinkKey, ExternalLink[]>>;
 
 const CATEGORY_LAYOUT = [
   ["Clinical significance", "Cross species"],
-  ["Frequency", "Haplotype"],
-  ["Splicing variant"],
+  ["Frequency", "Splicing variant"],
 ] as const;
 
 const CATEGORY_ANCHORS: Record<string, string> = {
@@ -161,26 +160,19 @@ const buildLinkCategoryRows = (
             firstExternalLink(externalLinks, "dbsnp"),
           ),
           buildSourceFromExternalLink(
-            "gnomAD",
-            firstExternalLink(externalLinks, "gnomad"),
-            "gnomad",
-          ),
-          buildSourceFromExternalLink(
             "ToMMo",
             firstExternalLink(externalLinks, "tommo"),
             "tommo",
           ),
-        ],
-      },
-    ],
-    [
-      "Haplotype",
-      {
-        label: "Haplotype",
-        sources: [
           buildSourceFromExternalLink(
             "JoGo",
             firstExternalLink(externalLinks, "jogo"),
+            "jogo",
+          ),
+          buildSourceFromExternalLink(
+            "gnomAD",
+            firstExternalLink(externalLinks, "gnomad"),
+            "gnomad",
           ),
         ],
       },

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -1,0 +1,162 @@
+import Stanza from "togostanza/stanza";
+
+import * as display from "@/lib/display";
+import { ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
+import {
+  buildSparqlistApiUrl,
+  fetchSparqlBindings,
+  requireFirstBinding,
+} from "@/lib/sparqlist";
+import type {
+  SparqlistStanzaParams,
+  SparqlistTemplateRenderParams,
+} from "@/lib/types";
+
+// ============================================================
+// 型定義
+// ============================================================
+
+/**
+ * variant_summary API のバインディングローデータ。
+ * reference フィールドは "…/chr/assembly" 形式の URI で、表示前に分解が必要。
+ */
+interface VariantSummarySparqlBinding {
+  /** 染色体・アセンブリを含む参照ゲノムURI（例: "http://identifiers.org/hco/1/GRCh38"） */
+  reference?: string;
+  type?: string;
+  position?: string;
+  ref?: string;
+  alt?: string;
+  gene?: string; // Ensembl 遺伝子 URI
+  hgnc?: string; // "http://identifiers.org/hgnc/{id}" 形式のURI。リンクに直接使える。
+  symbol?: string; // HGNC 承認シンボル（例: "PLEKHG5"）
+  approved_name?: string; // HGNC 承認名（例: "pleckstrin homology and RhoGEF..."）
+}
+
+/**
+ * Handlebars テンプレートへ渡す variant_summary の表示データ。
+ * reference URI を分解した chr / assembly を追加し、
+ * ref / alt は表示用に整形済みの値に差し替えてある。
+ * gene/hgnc/symbol/approved_name は GeneDisplayData 側で扱うため除外する。
+ */
+interface VariantSummaryDisplayData extends Omit<
+  VariantSummarySparqlBinding,
+  "reference" | "gene" | "hgnc" | "symbol" | "approved_name"
+> {
+  chr?: string;
+  assembly?: string;
+  /** display.refAlt() が展開する表示用フィールド群 */
+  ref?: string;
+  alt?: string;
+  ref_length?: number;
+  alt_length?: number;
+}
+
+/**
+ * Handlebars テンプレートへ渡す遺伝子の表示データ。
+ * 複数 synonym が返る binding から1遺伝子分に集約している。
+ */
+interface GeneDisplayData {
+  symbol?: string;
+  /** TogoVar内部の遺伝子ページへのリンク(`/gene/{hgnc_id}`)。テンプレートでリンクの href に直接使える。 */
+  hgnc_url?: string;
+  approved_name?: string;
+}
+
+/** renderTemplate に渡すパラメータ全体。エラー時は result を持たない。 */
+interface TemplateRenderParams extends SparqlistTemplateRenderParams<VariantSummaryDisplayData> {
+  /** 遺伝子情報。バリアントが遺伝子領域外の場合は undefined。 */
+  gene?: GeneDisplayData;
+}
+
+// ============================================================
+// データ変換（バインディング → 表示データ）
+// ============================================================
+
+/**
+ * variant_summary バインディング1件をテンプレート表示データへ変換する。
+ *
+ * 変換内容:
+ * - reference URI → chr / assembly の分離
+ * - ref / alt → display.refAlt() で表示文字列・長さフィールドに展開
+ */
+const convertSummaryBindingToDisplayData = (
+  binding: VariantSummarySparqlBinding,
+): VariantSummaryDisplayData => {
+  const { reference, ...sharedFields } = binding;
+
+  const displayData: VariantSummaryDisplayData = {
+    ...sharedFields,
+    ...display.referenceToChrAssembly(reference),
+  };
+
+  // ref / alt の長さが4文字を超える場合は "ACGT..." に省略する（display.refAlt の仕様）
+  Object.assign(displayData, display.refAlt(binding.ref, binding.alt));
+
+  return displayData;
+};
+
+/**
+ * variant_summary バインディングから遺伝子表示データを組み立てる。
+ * バリアントが遺伝子領域外の場合は symbol 等が undefined になるため、
+ * その場合は表示データなし（undefined）として扱う。
+ */
+const convertSummaryBindingToGeneDisplayData = (
+  binding: VariantSummarySparqlBinding,
+): GeneDisplayData | undefined => {
+  if (!binding.symbol) {
+    return undefined;
+  }
+
+  return {
+    symbol: binding.symbol,
+    // TogoVar内部の遺伝子ページへのリンク。hgnc は "http://identifiers.org/hgnc/{id}" 形式のURIなので末尾のIDを取り出す。
+    hgnc_url: binding.hgnc
+      ? `/gene/${binding.hgnc.split("/").pop()}`
+      : undefined,
+    approved_name: binding.approved_name,
+  };
+};
+
+// ============================================================
+// Stanza クラス
+// ============================================================
+
+export default class VariantSummary extends Stanza {
+  /**
+   * Togostanza フレームワークが描画ごとに呼び出すエントリーポイント。
+   * variant_summary の結果に gene/hgnc/symbol/approved_name も含まれるため、
+   * 1回の fetch のみで済ませている。
+   */
+  async render(): Promise<void> {
+    // フォントは描画前に非同期ロード開始しておく（ロード完了を待たず続行する）
+    this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
+
+    const params = this.params as SparqlistStanzaParams;
+
+    const templateParams: TemplateRenderParams = { params };
+
+    try {
+      const summaryApiUrl = buildSparqlistApiUrl("variant_summary", params);
+      const bindings =
+        await fetchSparqlBindings<VariantSummarySparqlBinding>(summaryApiUrl);
+      const firstBinding = requireFirstBinding(
+        bindings,
+        `Variant not found for ${params.tgv_id}`,
+      );
+
+      templateParams.result = convertSummaryBindingToDisplayData(firstBinding);
+      templateParams.gene =
+        convertSummaryBindingToGeneDisplayData(firstBinding);
+    } catch (reason) {
+      templateParams.error = {
+        message: reason instanceof Error ? reason.message : String(reason),
+      };
+    }
+
+    this.renderTemplate({
+      template: "stanza.html.hbs",
+      parameters: templateParams,
+    });
+  }
+}

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -129,6 +129,18 @@ const firstExternalLink = (
   return externalLinks[key]?.[0];
 };
 
+const requireFirstVariantData = (
+  apiResponse: TogoVarApiResponse,
+  tgvId: string,
+): VariantData => {
+  const variantData = apiResponse.data[0];
+  if (!variantData) {
+    throw new Error(`Variant not found for ${tgvId}`);
+  }
+
+  return variantData;
+};
+
 const normalizeMogplusEntry = (json: unknown): MogplusEntry | undefined => {
   if (Array.isArray(json)) {
     return json[0] as MogplusEntry | undefined;
@@ -219,17 +231,23 @@ const fetchMogplusEntry = async (
     return undefined;
   }
 
-  const apiUrl = buildMogplusApiUrl(sparqlist, variant, mogplusVersion);
-  const response = await fetch(apiUrl, {
-    method: "GET",
-    headers: { Accept: "application/json" },
-  });
+  try {
+    const apiUrl = buildMogplusApiUrl(sparqlist, variant, mogplusVersion);
+    const response = await fetch(apiUrl, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+    });
 
-  if (!response.ok) {
-    throw new Error(`${apiUrl} returned status ${response.status}`);
+    if (!response.ok) {
+      throw new Error(`${apiUrl} returned status ${response.status}`);
+    }
+
+    return normalizeMogplusEntry(await response.json());
+  } catch (error) {
+    // MoG+ は補助リンクなので、取得失敗時も他DBリンクの表示は継続する。
+    console.warn(error);
+    return undefined;
   }
-
-  return normalizeMogplusEntry(await response.json());
 };
 
 const buildLinkCategoryRows = (
@@ -347,10 +365,11 @@ export default class VariantLinks extends Stanza {
       }
 
       const apiResponse = await fetchVariantLinks(dataUrl, tgvId);
+      const variantData = requireFirstVariantData(apiResponse, tgvId);
       const mogplusVersion = params.mogplus_ver ?? DEFAULT_MOGPLUS_VERSION;
       const mogplusEntry = await fetchMogplusEntry(
         params.sparqlist,
-        apiResponse.data[0],
+        variantData,
         mogplusVersion,
       );
       templateParams.result = buildLinkCategoryRows(

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -1,154 +1,181 @@
 import Stanza from "togostanza/stanza";
 
-import * as display from "@/lib/display";
 import { ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
-import {
-  buildSparqlistApiUrl,
-  fetchSparqlBindings,
-  requireFirstBinding,
-} from "@/lib/sparqlist";
-import type {
-  SparqlistStanzaParams,
-  SparqlistTemplateRenderParams,
-} from "@/lib/types";
+import { buildSparqlistApiUrl } from "@/lib/sparqlist";
+import type { SparqlistStanzaParams } from "@/lib/types";
 
 // ============================================================
 // 型定義
 // ============================================================
 
-/**
- * variant_summary API のバインディングローデータ。
- * reference フィールドは "…/chr/assembly" 形式の URI で、表示前に分解が必要。
- */
-interface VariantSummarySparqlBinding {
-  /** 染色体・アセンブリを含む参照ゲノムURI（例: "http://identifiers.org/hco/1/GRCh38"） */
-  reference?: string;
-  type?: string;
-  position?: string;
-  ref?: string;
-  alt?: string;
-  gene?: string; // Ensembl 遺伝子 URI
-  hgnc?: string; // "http://identifiers.org/hgnc/{id}" 形式のURI。リンクに直接使える。
-  symbol?: string; // HGNC 承認シンボル（例: "PLEKHG5"）
-  approved_name?: string; // HGNC 承認名（例: "pleckstrin homology and RhoGEF..."）
+/** 1つの外部データベースへのリンク。url が無い場合はテンプレート側で "N/A" と表示する。 */
+interface LinkSource {
+  /** データベース表示名（例: "ClinVar"） */
+  name: string;
+  /** 表示値（例: "12-111803962-G-A"）。URLが無い場合はプレーンテキストで表示する。 */
+  value?: string;
+  url?: string;
+  /** リンク先URLが無くてもデータが存在する場合は true。 */
+  available: boolean;
 }
 
-/**
- * Handlebars テンプレートへ渡す variant_summary の表示データ。
- * reference URI を分解した chr / assembly を追加し、
- * ref / alt は表示用に整形済みの値に差し替えてある。
- * gene/hgnc/symbol/approved_name は GeneDisplayData 側で扱うため除外する。
- */
-interface VariantSummaryDisplayData extends Omit<
-  VariantSummarySparqlBinding,
-  "reference" | "gene" | "hgnc" | "symbol" | "approved_name"
-> {
-  chr?: string;
-  assembly?: string;
-  /** display.refAlt() が展開する表示用フィールド群 */
-  ref?: string;
-  alt?: string;
-  ref_length?: number;
-  alt_length?: number;
+/** 表の1セル分（Clinical significance, Frequency など1カテゴリ分）。 */
+interface LinkCategory {
+  label: string;
+  /**
+   * ページ内アンカーへのリンク(例: "#clinical-significance")。
+   * 同じページに埋め込まれた他のstanza(variant-clinvarなど)の表示位置へジャンプする用途。
+   * 無い場合はテンプレート側でリンクなしのラベルとして表示する。
+   */
+  anchor?: string;
+  sources: LinkSource[];
 }
 
-/**
- * Handlebars テンプレートへ渡す遺伝子の表示データ。
- * 複数 synonym が返る binding から1遺伝子分に集約している。
- */
-interface GeneDisplayData {
-  symbol?: string;
-  /** TogoVar内部の遺伝子ページへのリンク(`/gene/{hgnc_id}`)。テンプレートでリンクの href に直接使える。 */
-  hgnc_url?: string;
-  approved_name?: string;
+/** 表の1行。right が無い場合は右側2カラムを空セルにする(例: Splicing variantの行)。 */
+interface LinkCategoryRow {
+  left: LinkCategory;
+  right?: LinkCategory;
 }
 
 /** renderTemplate に渡すパラメータ全体。エラー時は result を持たない。 */
-interface TemplateRenderParams extends SparqlistTemplateRenderParams<VariantSummaryDisplayData> {
-  /** 遺伝子情報。バリアントが遺伝子領域外の場合は undefined。 */
-  gene?: GeneDisplayData;
+interface TemplateRenderParams {
+  params: VariantLinksParams;
+  result?: LinkCategoryRow[];
+  error?: {
+    message: string;
+  };
 }
 
-// ============================================================
-// データ変換（バインディング → 表示データ）
-// ============================================================
+interface VariantLinksParams extends SparqlistStanzaParams {
+  /** chr-pos-ref-alt形式のバリアント表記。variant_links API が対応している場合に渡す。 */
+  variant?: string;
+}
 
-/**
- * variant_summary バインディング1件をテンプレート表示データへ変換する。
- *
- * 変換内容:
- * - reference URI → chr / assembly の分離
- * - ref / alt → display.refAlt() で表示文字列・長さフィールドに展開
- */
-const convertSummaryBindingToDisplayData = (
-  binding: VariantSummarySparqlBinding,
-): VariantSummaryDisplayData => {
-  const { reference, ...sharedFields } = binding;
+interface VariantLinkRawEntry {
+  category?: string;
+  source?: string;
+  title?: string | null;
+  id?: string | null;
+  url?: string | null;
+  available?: boolean;
+}
 
-  const displayData: VariantSummaryDisplayData = {
-    ...sharedFields,
-    ...display.referenceToChrAssembly(reference),
-  };
+const CATEGORY_LAYOUT = [
+  ["Clinical significance", "Cross species"],
+  ["Frequency", "Haplotype"],
+  ["Splicing variant"],
+];
 
-  // ref / alt の長さが4文字を超える場合は "ACGT..." に省略する（display.refAlt の仕様）
-  Object.assign(displayData, display.refAlt(binding.ref, binding.alt));
-
-  return displayData;
+const CATEGORY_ANCHORS: Record<string, string> = {
+  "Clinical significance": "#clinical-significance-mgend",
+  Frequency: "#frequency",
 };
 
-/**
- * variant_summary バインディングから遺伝子表示データを組み立てる。
- * バリアントが遺伝子領域外の場合は symbol 等が undefined になるため、
- * その場合は表示データなし（undefined）として扱う。
- */
-const convertSummaryBindingToGeneDisplayData = (
-  binding: VariantSummarySparqlBinding,
-): GeneDisplayData | undefined => {
-  if (!binding.symbol) {
-    return undefined;
+const buildVariantLinksApiUrl = (params: VariantLinksParams): string => {
+  if (!params.tgv_id && !params.variant) {
+    throw new Error("Either tgv_id or variant parameter is required");
   }
 
+  return buildSparqlistApiUrl("variant_links", params, {
+    variant: params.variant,
+  });
+};
+
+const fetchVariantLinks = async (
+  apiUrl: string,
+): Promise<VariantLinkRawEntry[]> => {
+  const response = await fetch(apiUrl, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`${apiUrl} returns status ${response.status}`);
+  }
+
+  const json: unknown = await response.json();
+  if (!Array.isArray(json)) {
+    throw new Error("variant_links response must be an array");
+  }
+
+  return json as VariantLinkRawEntry[];
+};
+
+const buildLinkSource = (entry: VariantLinkRawEntry): LinkSource => ({
+  name: entry.source ?? "",
+  value: entry.title ?? entry.id ?? undefined,
+  url: entry.url ?? undefined,
+  available: entry.available === true,
+});
+
+const buildLinkCategory = (
+  category: string,
+  entriesByCategory: Map<string, VariantLinkRawEntry[]>,
+): LinkCategory | undefined => {
+  const entries = entriesByCategory.get(category);
+  if (!entries) return undefined;
+
   return {
-    symbol: binding.symbol,
-    // TogoVar内部の遺伝子ページへのリンク。hgnc は "http://identifiers.org/hgnc/{id}" 形式のURIなので末尾のIDを取り出す。
-    hgnc_url: binding.hgnc
-      ? `/gene/${binding.hgnc.split("/").pop()}`
-      : undefined,
-    approved_name: binding.approved_name,
+    label: category,
+    anchor: CATEGORY_ANCHORS[category],
+    sources: entries.map(buildLinkSource),
   };
+};
+
+const buildLinkCategoryRows = (
+  entries: VariantLinkRawEntry[],
+): LinkCategoryRow[] => {
+  const entriesByCategory = entries.reduce<Map<string, VariantLinkRawEntry[]>>(
+    (accumulator, entry) => {
+      if (!entry.category) return accumulator;
+      const categoryEntries = accumulator.get(entry.category) ?? [];
+      categoryEntries.push(entry);
+      accumulator.set(entry.category, categoryEntries);
+      return accumulator;
+    },
+    new Map(),
+  );
+
+  return CATEGORY_LAYOUT.flatMap(([leftCategory, rightCategory]) => {
+    const left = buildLinkCategory(leftCategory, entriesByCategory);
+    if (!left) return [];
+
+    const right = rightCategory
+      ? buildLinkCategory(rightCategory, entriesByCategory)
+      : undefined;
+
+    return [{ left, right }];
+  });
 };
 
 // ============================================================
 // Stanza クラス
 // ============================================================
 
-export default class VariantSummary extends Stanza {
-  /**
-   * Togostanza フレームワークが描画ごとに呼び出すエントリーポイント。
-   * variant_summary の結果に gene/hgnc/symbol/approved_name も含まれるため、
-   * 1回の fetch のみで済ませている。
-   */
+export default class VariantLinks extends Stanza {
+  /** 再描画のたびに張り直すクリックリスナーを、disconnect時にまとめて解除するために保持する。 */
+  private cleanupAnchorLinks: (() => void)[] = [];
+
+  disconnectedCallback() {
+    this.cleanupAnchorLinks.forEach((cleanup) => cleanup());
+    this.cleanupAnchorLinks = [];
+  }
+
   async render(): Promise<void> {
-    // フォントは描画前に非同期ロード開始しておく（ロード完了を待たず続行する）
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
-    const params = this.params as SparqlistStanzaParams;
+    const params = this.params as VariantLinksParams;
 
-    const templateParams: TemplateRenderParams = { params };
+    const templateParams: TemplateRenderParams = {
+      params,
+    };
 
     try {
-      const summaryApiUrl = buildSparqlistApiUrl("variant_summary", params);
-      const bindings =
-        await fetchSparqlBindings<VariantSummarySparqlBinding>(summaryApiUrl);
-      const firstBinding = requireFirstBinding(
-        bindings,
-        `Variant not found for ${params.tgv_id}`,
-      );
-
-      templateParams.result = convertSummaryBindingToDisplayData(firstBinding);
-      templateParams.gene =
-        convertSummaryBindingToGeneDisplayData(firstBinding);
+      const apiUrl = buildVariantLinksApiUrl(params);
+      const rawEntries = await fetchVariantLinks(apiUrl);
+      templateParams.result = buildLinkCategoryRows(rawEntries);
     } catch (reason) {
+      console.error(reason);
       templateParams.error = {
         message: reason instanceof Error ? reason.message : String(reason),
       };
@@ -158,5 +185,42 @@ export default class VariantSummary extends Stanza {
       template: "stanza.html.hbs",
       parameters: templateParams,
     });
+
+    this.setupAnchorScrolling();
+  }
+
+  /**
+   * category-link はページ内アンカー("#id")へのリンク。
+   * このstanza自身はShadow DOM内に描画されるため、ブラウザ標準のアンカー遷移(#idジャンプ)は
+   * 対象要素がライトDOM側にあれば動作するはずだが、確実にスクロールさせるため
+   * document.getElementById() で明示的に探して scrollIntoView する。
+   * 対象が見つからない場合(単体プレビュー時など)はデフォルトのリンク遷移に任せる。
+   */
+  private setupAnchorScrolling() {
+    this.cleanupAnchorLinks.forEach((cleanup) => cleanup());
+    this.cleanupAnchorLinks = [];
+
+    this.root
+      .querySelectorAll<HTMLAnchorElement>(".category-link")
+      .forEach((link) => {
+        const handleClick = (event: MouseEvent) => {
+          const targetId = link.getAttribute("href")?.replace(/^#/, "");
+          const targetElement = targetId
+            ? document.getElementById(targetId)
+            : null;
+
+          if (!targetElement) {
+            return;
+          }
+
+          event.preventDefault();
+          targetElement.scrollIntoView({ behavior: "smooth", block: "start" });
+        };
+
+        link.addEventListener("click", handleClick);
+        this.cleanupAnchorLinks.push(() =>
+          link.removeEventListener("click", handleClick),
+        );
+      });
   }
 }

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -9,7 +9,7 @@ import {
   requireVariantData,
 } from "@/lib/togovar-variant";
 import type { ParsedVariant } from "@/lib/variant";
-import { parseVariantParam } from "@/lib/variant";
+import { assertValidVariantIdentifier, parseVariantParam } from "@/lib/variant";
 
 // ============================================================
 // 型定義
@@ -375,9 +375,7 @@ export default class VariantLinks extends Stanza {
       if (!dataUrl) {
         throw new Error("data-url parameter is required");
       }
-      if (!tgvId && !parsedVariant) {
-        throw new Error("tgv_id or variant parameter is required");
-      }
+      assertValidVariantIdentifier(tgvId, params.variant, parsedVariant);
 
       const apiResponse = tgvId
         ? await fetchVariantDataById(dataUrl, tgvId)

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -1,7 +1,10 @@
 import Stanza from "togostanza/stanza";
 
 import { ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
+import { describeVariantIdentifier } from "@/lib/sparqlist";
 import type { ExternalLink, TogoVarApiResponse, VariantData } from "@/lib/types";
+import { normalizeChromosome, parseVariantParam } from "@/lib/variant";
+import type { ParsedVariant } from "@/lib/variant";
 
 // ============================================================
 // 型定義
@@ -49,6 +52,7 @@ interface TemplateRenderParams {
 
 interface VariantLinksParams {
   tgv_id?: string;
+  variant?: string;
   "data-url"?: string;
   sparqlist?: string;
   mogplus_ver?: string;
@@ -61,8 +65,7 @@ type ExternalLinkKey =
   | "gnomad"
   | "tommo"
   | "jogo"
-  | "sscv_db"
-  | "mog";
+  | "sscv_db";
 
 type VariantExternalLinks = Partial<Record<ExternalLinkKey, ExternalLink[]>>;
 
@@ -90,9 +93,9 @@ const CATEGORY_ANCHORS: Record<string, string> = {
   Frequency: "#frequency",
 };
 
-const fetchVariantLinks = async (
+const postVariantQuery = async (
   dataUrl: string,
-  tgvId: string,
+  query: Record<string, unknown>,
 ): Promise<TogoVarApiResponse> => {
   const response = await fetch(dataUrl, {
     method: "POST",
@@ -100,7 +103,7 @@ const fetchVariantLinks = async (
       Accept: "application/json",
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ query: { id: [tgvId] } }),
+    body: JSON.stringify({ query }),
   });
 
   if (!response.ok) {
@@ -109,6 +112,28 @@ const fetchVariantLinks = async (
 
   return response.json() as Promise<TogoVarApiResponse>;
 };
+
+const fetchVariantDataById = (
+  dataUrl: string,
+  tgvId: string,
+): Promise<TogoVarApiResponse> => postVariantQuery(dataUrl, { id: [tgvId] });
+
+/**
+ * tgv_id を持たないバリアント（TogoVar未登録）を variant(CHROM-POS-REF-ALT) で解決する。
+ * TogoVar検索APIは variant 表記そのものでの検索に対応していないため、
+ * jogo-haplotype-explorer と同じ location(chromosome/position) クエリで候補を取得し、
+ * reference/alternate が一致するものを呼び出し側で絞り込む。
+ */
+const fetchVariantDataByLocation = (
+  dataUrl: string,
+  parsedVariant: ParsedVariant,
+): Promise<TogoVarApiResponse> =>
+  postVariantQuery(dataUrl, {
+    location: {
+      chromosome: normalizeChromosome(parsedVariant.chromosome),
+      position: Number(parsedVariant.position),
+    },
+  });
 
 const buildSourceFromExternalLink = (
   name: string,
@@ -129,13 +154,31 @@ const firstExternalLink = (
   return externalLinks[key]?.[0];
 };
 
-const requireFirstVariantData = (
+/**
+ * tgv_id 指定時は検索結果の先頭を採用する(id指定なので1件のはず)。
+ * variant 指定時は location クエリで同一位置の候補が複数返り得るため、
+ * reference/alternate が入力と一致するものを探す(multi-allelicサイト対策)。
+ */
+const requireVariantData = (
   apiResponse: TogoVarApiResponse,
-  tgvId: string,
+  tgvId: string | undefined,
+  parsedVariant: ParsedVariant | undefined,
+  identifier: string,
 ): VariantData => {
-  const variantData = apiResponse.data[0];
+  const variantData = tgvId
+    ? apiResponse.data[0]
+    : apiResponse.data.find(
+        (data) =>
+          parsedVariant !== undefined &&
+          normalizeChromosome(data.chromosome) ===
+            normalizeChromosome(parsedVariant.chromosome) &&
+          String(data.position) === parsedVariant.position &&
+          data.reference === parsedVariant.reference &&
+          data.alternate === parsedVariant.alternate,
+      );
+
   if (!variantData) {
-    throw new Error(`Variant not found for ${tgvId}`);
+    throw new Error(`Variant not found for ${identifier}`);
   }
 
   return variantData;
@@ -200,7 +243,6 @@ const buildMogplusSourceUrl = (
     `chrStart=${Number(entry.pos) - 500}`,
     `chrEnd=${Number(entry.pos) + 500}`,
     "seqType=genome",
-    `chrName=${encodeURIComponent(entry.chr)}`,
     "geneNameSearchText=",
     "index=submit",
     "presentType=disp",
@@ -251,11 +293,11 @@ const fetchMogplusEntry = async (
 };
 
 const buildLinkCategoryRows = (
-  apiResponse: TogoVarApiResponse,
+  variantData: VariantData,
   mogplusEntry: MogplusEntry | undefined,
   mogplusVersion: string,
 ): LinkCategoryRow[] => {
-  const externalLinks = (apiResponse.data[0]?.external_links ??
+  const externalLinks = (variantData.external_links ??
     {}) as VariantExternalLinks;
 
   const categories = new Map<string, LinkCategory>([
@@ -351,6 +393,7 @@ export default class VariantLinks extends Stanza {
     const params = this.params as VariantLinksParams;
     const dataUrl = params["data-url"];
     const tgvId = params.tgv_id;
+    const parsedVariant = parseVariantParam(params.variant);
 
     const templateParams: TemplateRenderParams = {
       params,
@@ -360,12 +403,22 @@ export default class VariantLinks extends Stanza {
       if (!dataUrl) {
         throw new Error("data-url parameter is required");
       }
-      if (!tgvId) {
-        throw new Error("tgv_id parameter is required");
+      if (!tgvId && !parsedVariant) {
+        throw new Error("tgv_id or variant parameter is required");
       }
 
-      const apiResponse = await fetchVariantLinks(dataUrl, tgvId);
-      const variantData = requireFirstVariantData(apiResponse, tgvId);
+      const apiResponse = tgvId
+        ? await fetchVariantDataById(dataUrl, tgvId)
+        : await fetchVariantDataByLocation(
+            dataUrl,
+            parsedVariant as ParsedVariant,
+          );
+      const variantData = requireVariantData(
+        apiResponse,
+        tgvId,
+        parsedVariant,
+        describeVariantIdentifier(params),
+      );
       const mogplusVersion = params.mogplus_ver ?? DEFAULT_MOGPLUS_VERSION;
       const mogplusEntry = await fetchMogplusEntry(
         params.sparqlist,
@@ -373,7 +426,7 @@ export default class VariantLinks extends Stanza {
         mogplusVersion,
       );
       templateParams.result = buildLinkCategoryRows(
-        apiResponse,
+        variantData,
         mogplusEntry,
         mogplusVersion,
       );

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -1,8 +1,7 @@
 import Stanza from "togostanza/stanza";
 
 import { ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
-import { buildSparqlistApiUrl } from "@/lib/sparqlist";
-import type { SparqlistStanzaParams } from "@/lib/types";
+import type { ExternalLink, TogoVarApiResponse } from "@/lib/types";
 
 // ============================================================
 // 型定義
@@ -12,6 +11,8 @@ import type { SparqlistStanzaParams } from "@/lib/types";
 interface LinkSource {
   /** データベース表示名（例: "ClinVar"） */
   name: string;
+  /** variant-frequency と同じ dataset icon を表示する場合に使う dataset ID。 */
+  dataset?: string;
   /** 表示値（例: "12-111803962-G-A"）。URLが無い場合はプレーンテキストで表示する。 */
   value?: string;
   url?: string;
@@ -46,106 +47,162 @@ interface TemplateRenderParams {
   };
 }
 
-interface VariantLinksParams extends SparqlistStanzaParams {
-  /** chr-pos-ref-alt形式のバリアント表記。variant_links API が対応している場合に渡す。 */
-  variant?: string;
+interface VariantLinksParams {
+  tgv_id?: string;
+  "data-url"?: string;
 }
 
-interface VariantLinkRawEntry {
-  category?: string;
-  source?: string;
-  title?: string | null;
-  id?: string | null;
-  url?: string | null;
-  available?: boolean;
-}
+type ExternalLinkKey =
+  | "clinvar"
+  | "mgend"
+  | "dbsnp"
+  | "gnomad"
+  | "tommo"
+  | "jogo"
+  | "sscvdb"
+  | "mog";
+
+type VariantExternalLinks = Partial<Record<ExternalLinkKey, ExternalLink[]>>;
 
 const CATEGORY_LAYOUT = [
   ["Clinical significance", "Cross species"],
   ["Frequency", "Haplotype"],
   ["Splicing variant"],
-];
+] as const;
 
 const CATEGORY_ANCHORS: Record<string, string> = {
   "Clinical significance": "#clinical-significance-mgend",
   Frequency: "#frequency",
 };
 
-const buildVariantLinksApiUrl = (params: VariantLinksParams): string => {
-  if (!params.tgv_id && !params.variant) {
-    throw new Error("Either tgv_id or variant parameter is required");
-  }
-
-  return buildSparqlistApiUrl("variant_links", params, {
-    variant: params.variant,
-  });
-};
-
 const fetchVariantLinks = async (
-  apiUrl: string,
-): Promise<VariantLinkRawEntry[]> => {
-  const response = await fetch(apiUrl, {
-    method: "GET",
-    headers: { Accept: "application/json" },
+  dataUrl: string,
+  tgvId: string,
+): Promise<TogoVarApiResponse> => {
+  const response = await fetch(dataUrl, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: { id: [tgvId] } }),
   });
 
   if (!response.ok) {
-    throw new Error(`${apiUrl} returns status ${response.status}`);
+    throw new Error(`${dataUrl} returned status ${response.status}`);
   }
 
-  const json: unknown = await response.json();
-  if (!Array.isArray(json)) {
-    throw new Error("variant_links response must be an array");
-  }
-
-  return json as VariantLinkRawEntry[];
+  return response.json() as Promise<TogoVarApiResponse>;
 };
 
-const buildLinkSource = (entry: VariantLinkRawEntry): LinkSource => ({
-  name: entry.source ?? "",
-  value: entry.title ?? entry.id ?? undefined,
-  url: entry.url ?? undefined,
-  available: entry.available === true,
+const buildSourceFromExternalLink = (
+  name: string,
+  link: ExternalLink | undefined,
+  dataset?: string,
+): LinkSource => ({
+  name,
+  dataset,
+  value: link?.title,
+  url: link?.xref,
+  available: Boolean(link),
 });
 
-const buildLinkCategory = (
-  category: string,
-  entriesByCategory: Map<string, VariantLinkRawEntry[]>,
-): LinkCategory | undefined => {
-  const entries = entriesByCategory.get(category);
-  if (!entries) return undefined;
-
-  return {
-    label: category,
-    anchor: CATEGORY_ANCHORS[category],
-    sources: entries.map(buildLinkSource),
-  };
+const firstExternalLink = (
+  externalLinks: VariantExternalLinks,
+  key: ExternalLinkKey,
+): ExternalLink | undefined => {
+  return externalLinks[key]?.[0];
 };
 
 const buildLinkCategoryRows = (
-  entries: VariantLinkRawEntry[],
+  apiResponse: TogoVarApiResponse,
 ): LinkCategoryRow[] => {
-  const entriesByCategory = entries.reduce<Map<string, VariantLinkRawEntry[]>>(
-    (accumulator, entry) => {
-      if (!entry.category) return accumulator;
-      const categoryEntries = accumulator.get(entry.category) ?? [];
-      categoryEntries.push(entry);
-      accumulator.set(entry.category, categoryEntries);
-      return accumulator;
-    },
-    new Map(),
-  );
+  const externalLinks = (apiResponse.data[0]?.external_links ??
+    {}) as VariantExternalLinks;
 
-  return CATEGORY_LAYOUT.flatMap(([leftCategory, rightCategory]) => {
-    const left = buildLinkCategory(leftCategory, entriesByCategory);
-    if (!left) return [];
+  const categories = new Map<string, LinkCategory>([
+    [
+      "Clinical significance",
+      {
+        label: "Clinical significance",
+        anchor: CATEGORY_ANCHORS["Clinical significance"],
+        sources: [
+          buildSourceFromExternalLink(
+            "ClinVar",
+            firstExternalLink(externalLinks, "clinvar"),
+          ),
+          buildSourceFromExternalLink(
+            "MGeND",
+            firstExternalLink(externalLinks, "mgend"),
+          ),
+        ],
+      },
+    ],
+    [
+      "Cross species",
+      {
+        label: "Cross species",
+        sources: [
+          buildSourceFromExternalLink(
+            "MoG+ (Mouse)",
+            firstExternalLink(externalLinks, "mog"),
+          ),
+        ],
+      },
+    ],
+    [
+      "Frequency",
+      {
+        label: "Frequency",
+        anchor: CATEGORY_ANCHORS.Frequency,
+        sources: [
+          buildSourceFromExternalLink(
+            "dbSNP",
+            firstExternalLink(externalLinks, "dbsnp"),
+          ),
+          buildSourceFromExternalLink(
+            "ToMMo",
+            firstExternalLink(externalLinks, "tommo"),
+            "tommo",
+          ),
+          buildSourceFromExternalLink(
+            "gnomAD",
+            firstExternalLink(externalLinks, "gnomad"),
+            "gnomad",
+          ),
+        ],
+      },
+    ],
+    [
+      "Haplotype",
+      {
+        label: "Haplotype",
+        sources: [
+          buildSourceFromExternalLink(
+            "JoGo",
+            firstExternalLink(externalLinks, "jogo"),
+          ),
+        ],
+      },
+    ],
+    [
+      "Splicing variant",
+      {
+        label: "Splicing variant",
+        sources: [
+          buildSourceFromExternalLink(
+            "SSCVDB",
+            firstExternalLink(externalLinks, "sscvdb"),
+          ),
+        ],
+      },
+    ],
+  ]);
 
-    const right = rightCategory
-      ? buildLinkCategory(rightCategory, entriesByCategory)
-      : undefined;
-
-    return [{ left, right }];
-  });
+  return CATEGORY_LAYOUT.map(([leftCategory, rightCategory]) => ({
+    left: categories.get(leftCategory) as LinkCategory,
+    right: rightCategory ? categories.get(rightCategory) : undefined,
+  }));
 };
 
 // ============================================================
@@ -165,15 +222,23 @@ export default class VariantLinks extends Stanza {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
     const params = this.params as VariantLinksParams;
+    const dataUrl = params["data-url"];
+    const tgvId = params.tgv_id;
 
     const templateParams: TemplateRenderParams = {
       params,
     };
 
     try {
-      const apiUrl = buildVariantLinksApiUrl(params);
-      const rawEntries = await fetchVariantLinks(apiUrl);
-      templateParams.result = buildLinkCategoryRows(rawEntries);
+      if (!dataUrl) {
+        throw new Error("data-url parameter is required");
+      }
+      if (!tgvId) {
+        throw new Error("tgv_id parameter is required");
+      }
+
+      const apiResponse = await fetchVariantLinks(dataUrl, tgvId);
+      templateParams.result = buildLinkCategoryRows(apiResponse);
     } catch (reason) {
       console.error(reason);
       templateParams.error = {

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -2,9 +2,14 @@ import Stanza from "togostanza/stanza";
 
 import { ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
 import { describeVariantIdentifier } from "@/lib/sparqlist";
-import type { ExternalLink, TogoVarApiResponse, VariantData } from "@/lib/types";
-import { normalizeChromosome, parseVariantParam } from "@/lib/variant";
+import type { ExternalLink, VariantData } from "@/lib/types";
+import {
+  fetchVariantDataById,
+  fetchVariantDataByLocation,
+  requireVariantData,
+} from "@/lib/togovar-variant";
 import type { ParsedVariant } from "@/lib/variant";
+import { parseVariantParam } from "@/lib/variant";
 
 // ============================================================
 // 型定義
@@ -93,48 +98,6 @@ const CATEGORY_ANCHORS: Record<string, string> = {
   Frequency: "#frequency",
 };
 
-const postVariantQuery = async (
-  dataUrl: string,
-  query: Record<string, unknown>,
-): Promise<TogoVarApiResponse> => {
-  const response = await fetch(dataUrl, {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ query }),
-  });
-
-  if (!response.ok) {
-    throw new Error(`${dataUrl} returned status ${response.status}`);
-  }
-
-  return response.json() as Promise<TogoVarApiResponse>;
-};
-
-const fetchVariantDataById = (
-  dataUrl: string,
-  tgvId: string,
-): Promise<TogoVarApiResponse> => postVariantQuery(dataUrl, { id: [tgvId] });
-
-/**
- * tgv_id を持たないバリアント（TogoVar未登録）を variant(CHROM-POS-REF-ALT) で解決する。
- * TogoVar検索APIは variant 表記そのものでの検索に対応していないため、
- * jogo-haplotype-explorer と同じ location(chromosome/position) クエリで候補を取得し、
- * reference/alternate が一致するものを呼び出し側で絞り込む。
- */
-const fetchVariantDataByLocation = (
-  dataUrl: string,
-  parsedVariant: ParsedVariant,
-): Promise<TogoVarApiResponse> =>
-  postVariantQuery(dataUrl, {
-    location: {
-      chromosome: normalizeChromosome(parsedVariant.chromosome),
-      position: Number(parsedVariant.position),
-    },
-  });
-
 const buildSourceFromExternalLink = (
   name: string,
   link: ExternalLink | undefined,
@@ -152,36 +115,6 @@ const firstExternalLink = (
   key: ExternalLinkKey,
 ): ExternalLink | undefined => {
   return externalLinks[key]?.[0];
-};
-
-/**
- * tgv_id 指定時は検索結果の先頭を採用する(id指定なので1件のはず)。
- * variant 指定時は location クエリで同一位置の候補が複数返り得るため、
- * reference/alternate が入力と一致するものを探す(multi-allelicサイト対策)。
- */
-const requireVariantData = (
-  apiResponse: TogoVarApiResponse,
-  tgvId: string | undefined,
-  parsedVariant: ParsedVariant | undefined,
-  identifier: string,
-): VariantData => {
-  const variantData = tgvId
-    ? apiResponse.data[0]
-    : apiResponse.data.find(
-        (data) =>
-          parsedVariant !== undefined &&
-          normalizeChromosome(data.chromosome) ===
-            normalizeChromosome(parsedVariant.chromosome) &&
-          String(data.position) === parsedVariant.position &&
-          data.reference === parsedVariant.reference &&
-          data.alternate === parsedVariant.alternate,
-      );
-
-  if (!variantData) {
-    throw new Error(`Variant not found for ${identifier}`);
-  }
-
-  return variantData;
 };
 
 const normalizeMogplusEntry = (json: unknown): MogplusEntry | undefined => {

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -59,7 +59,7 @@ type ExternalLinkKey =
   | "gnomad"
   | "tommo"
   | "jogo"
-  | "sscvdb"
+  | "sscv_db"
   | "mog";
 
 type VariantExternalLinks = Partial<Record<ExternalLinkKey, ExternalLink[]>>;
@@ -161,14 +161,14 @@ const buildLinkCategoryRows = (
             firstExternalLink(externalLinks, "dbsnp"),
           ),
           buildSourceFromExternalLink(
-            "ToMMo",
-            firstExternalLink(externalLinks, "tommo"),
-            "tommo",
-          ),
-          buildSourceFromExternalLink(
             "gnomAD",
             firstExternalLink(externalLinks, "gnomad"),
             "gnomad",
+          ),
+          buildSourceFromExternalLink(
+            "ToMMo",
+            firstExternalLink(externalLinks, "tommo"),
+            "tommo",
           ),
         ],
       },
@@ -192,7 +192,7 @@ const buildLinkCategoryRows = (
         sources: [
           buildSourceFromExternalLink(
             "SSCVDB",
-            firstExternalLink(externalLinks, "sscvdb"),
+            firstExternalLink(externalLinks, "sscv_db"),
           ),
         ],
       },

--- a/stanzas/variant-links/metadata.json
+++ b/stanzas/variant-links/metadata.json
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "stanza": "http://togostanza.org/resource/stanza#"
+  },
+  "@id": "variant-links",
+  "stanza:label": "Variant / Links",
+  "stanza:definition": "",
+  "stanza:license": "MIT",
+  "stanza:author": "PENQE",
+  "stanza:contributor": [],
+  "stanza:created": "2026-07-31",
+  "stanza:updated": "2026-07-31",
+  "stanza:parameter": [
+    {
+      "stanza:key": "tgv_id",
+      "stanza:example": "tgv219804",
+      "stanza:description": "TogoVar ID",
+      "stanza:required": true
+    },
+    {
+      "stanza:key": "sparqlist",
+      "stanza:example": "https://grch38.togovar.org/sparqlist",
+      "stanza:description": "SPARQList URL (required)",
+      "stanza:required": true
+    }
+  ],
+  "stanza:menu-placement": "bottom-right",
+  "stanza:style": [],
+  "stanza:incomingEvent": [],
+  "stanza:outgoingEvent": []
+}

--- a/stanzas/variant-links/metadata.json
+++ b/stanzas/variant-links/metadata.json
@@ -9,7 +9,7 @@
   "stanza:author": "PENQE",
   "stanza:contributor": [],
   "stanza:created": "2026-07-31",
-  "stanza:updated": "2026-08-12",
+  "stanza:updated": "2026-08-13",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
@@ -28,6 +28,12 @@
       "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
       "stanza:description": "TogoVar variant search API URL",
       "stanza:required": true
+    },
+    {
+      "stanza:key": "assembly",
+      "stanza:example": "GRCh38",
+      "stanza:description": "Assembly of the TogoVar variant coordinates. MoG+ lookup is enabled only for GRCh38.",
+      "stanza:required": false
     },
     {
       "stanza:key": "sparqlist",

--- a/stanzas/variant-links/metadata.json
+++ b/stanzas/variant-links/metadata.json
@@ -13,13 +13,19 @@
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
-      "stanza:example": "tgv219804",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:example": "tgv167913213",
+      "stanza:description": "TogoVar ID (required if variant is not provided)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "12-111803962-G-A",
+      "stanza:description": "Variant identifier in chr-pos-ref-alt format (required if tgv_id is not provided)",
+      "stanza:required": false
     },
     {
       "stanza:key": "sparqlist",
-      "stanza:example": "https://grch38.togovar.org/sparqlist",
+      "stanza:example": "http://localhost:3000",
       "stanza:description": "SPARQList URL (required)",
       "stanza:required": true
     }

--- a/stanzas/variant-links/metadata.json
+++ b/stanzas/variant-links/metadata.json
@@ -14,19 +14,13 @@
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv167913213",
-      "stanza:description": "TogoVar ID (required if variant is not provided)",
-      "stanza:required": false
+      "stanza:description": "TogoVar ID",
+      "stanza:required": true
     },
     {
-      "stanza:key": "variant",
-      "stanza:example": "12-111803962-G-A",
-      "stanza:description": "Variant identifier in chr-pos-ref-alt format (required if tgv_id is not provided)",
-      "stanza:required": false
-    },
-    {
-      "stanza:key": "sparqlist",
-      "stanza:example": "http://localhost:3000",
-      "stanza:description": "SPARQList URL (required)",
+      "stanza:key": "data-url",
+      "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
+      "stanza:description": "TogoVar variant search API URL",
       "stanza:required": true
     }
   ],

--- a/stanzas/variant-links/metadata.json
+++ b/stanzas/variant-links/metadata.json
@@ -26,7 +26,7 @@
     {
       "stanza:key": "data-url",
       "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
-      "stanza:description": "TogoVar variant search API URL",
+      "stanza:description": "TogoVar API base URL or variant search API URL",
       "stanza:required": true
     },
     {

--- a/stanzas/variant-links/metadata.json
+++ b/stanzas/variant-links/metadata.json
@@ -9,13 +9,19 @@
   "stanza:author": "PENQE",
   "stanza:contributor": [],
   "stanza:created": "2026-07-31",
-  "stanza:updated": "2026-07-31",
+  "stanza:updated": "2026-08-12",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv167913213",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "data-url",

--- a/stanzas/variant-links/metadata.json
+++ b/stanzas/variant-links/metadata.json
@@ -22,6 +22,18 @@
       "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
       "stanza:description": "TogoVar variant search API URL",
       "stanza:required": true
+    },
+    {
+      "stanza:key": "sparqlist",
+      "stanza:example": "https://stg-grch38.togovar.org/sparqlist",
+      "stanza:description": "SPARQList URL for MoG+ cross species links",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "mogplus_ver",
+      "stanza:example": "mogplus21",
+      "stanza:description": "MoG+ version",
+      "stanza:required": false
     }
   ],
   "stanza:menu-placement": "bottom-right",

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -91,6 +91,14 @@ main {
         color: var(--color-black);
       }
 
+      .dataset-icon {
+        display: inline-block;
+
+        &::before {
+          font-size: 12px;
+        }
+      }
+
       .source-link {
         color: var(--color-key-dark2);
         overflow-wrap: anywhere;

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -76,8 +76,13 @@ main {
         display: inline-block;
       }
 
+      .source-separator {
+        white-space: pre;
+      }
+
       .source-name {
         margin-right: 4px;
+        font-size: 12px;
         color: var(--color-black);
       }
 

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -1,53 +1,117 @@
 @use "@/assets/css/common";
 
 main {
-  // key-value ペアを2列グリッドで並べる説明リスト。
-  // dt が「項目名」、dd が「値」に対応し、4カラムのグリッドに配置される。
-  // 例: [Variant type] [SNV] [Ref / Alt] [A→T]
-  //     [Position]     [chr1:12345 (GRCh38)]
-  .variant-summary-list {
-    display: grid;
-
-    // max-content で各 dt 列をラベルの最大幅に自動調整する。
-    // 固定px だと "HGNC/Approved symbol" のような長いラベルが溢れるため。
-    grid-template-columns: max-content 1fr max-content 1fr;
-
-    // column-gap を使うと列間が空白トラックになり border-bottom が途切れる。
-    // 代わりに dd の padding-right でペア間の空きを作り、border を全幅で連続させる。
+  // 外部DBリンクは表の交点ではなく「項目名と値」の一覧なので dl で表現する。
+  // 見た目は従来と同じく、各行を 4カラム(ラベル・値・ラベル・値)のグリッドにする。
+  .variant-links-list {
     width: 100%;
     margin: 0;
     font-family: "Roboto Condensed", sans-serif;
 
-    dt,
-    dd {
-      // align-self はデフォルトの stretch のままにして、セルをロー全体の高さに引き伸ばす。
-      // align-self: center にすると各セルが内容高さで縮み、border-bottom がバラバラな位置に引かれる。
-      display: flex;
-      align-items: center;
-      padding: 3px 0;
-      line-height: 1.2;
+    .category-row {
+      display: grid;
+      grid-template-columns: 130px calc(50% - 130px) 90px calc(50% - 90px);
       border-bottom: 1px solid var(--color-table-border);
     }
 
-    dt {
-      padding-left: 10px;
+    .category-label {
+      padding: 4px 10px;
+      margin: 0;
       font-size: 12px;
       font-weight: bold;
+      line-height: 1.2;
       color: var(--color-black);
-    }
-
-    dd {
-      // ブラウザデフォルトの margin-left をリセットする
-      padding-right: 10px;
-      padding-left: 12px;
-      margin: 0;
-      font-size: 14px;
-      color: var(--color-black);
+      text-align: left;
       white-space: nowrap;
+      border-right: 1px solid var(--color-table-border);
 
-      .chromosome {
+      &.category-label-left {
+        grid-column: 1;
+      }
+
+      &.category-label-right {
+        grid-column: 3;
+      }
+
+      .category-link {
         font-weight: bold;
+        color: var(--color-key-dark2);
+        text-decoration: underline;
+
+        &:hover {
+          color: var(--color-key-dark1);
+        }
+      }
+
+      .caret-down {
+        display: inline-block;
+        margin-left: 4px;
+        font-family: FontAwesome;
+        font-size: 10px;
+
+        &::before {
+          content: var(--char-arrow-down-long);
+        }
       }
     }
+
+    .category-value {
+      padding: 4px 10px;
+      margin: 0;
+      font-size: 14px;
+      line-height: 1.2;
+      color: #444;
+      text-align: left;
+      white-space: normal;
+
+      &.category-value-left {
+        grid-column: 2;
+      }
+
+      &.category-value-right {
+        grid-column: 4;
+      }
+
+      .source {
+        display: inline-block;
+      }
+
+      .source-name {
+        margin-right: 4px;
+        color: var(--color-black);
+      }
+
+      .source-link {
+        color: var(--color-key-dark2);
+
+        &:hover {
+          color: var(--color-key-dark1);
+        }
+      }
+
+      .external-link-icon {
+        display: inline-block;
+        margin-left: 3px;
+        font-family: FontAwesome;
+        font-size: 10px;
+
+        &::before {
+          content: var(--char-external-link);
+        }
+      }
+
+      .not-available {
+        color: var(--color-gray);
+      }
+    }
+  }
+
+  .variant-links-no-data {
+    padding: 14px 0 0;
+    margin: 0;
+    font-family: "Roboto Condensed", sans-serif;
+    font-size: 14px;
+    color: #444;
+    text-align: center;
   }
 }

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -10,7 +10,9 @@ main {
 
     .category-row {
       display: grid;
-      grid-template-columns: 130px calc(50% - 130px) 90px calc(50% - 90px);
+
+      // variant-summary と同じ列幅にして、左右ペアの境界線を常に全体幅の50%に揃える。
+      grid-template-columns: 130px calc(50% - 130px) 120px calc(50% - 120px);
       border-bottom: 1px solid var(--color-table-border);
     }
 
@@ -107,6 +109,33 @@ main {
 
       .not-available {
         color: var(--color-gray);
+      }
+    }
+
+    @media (width <= 580px) {
+      .category-row {
+        grid-template-columns: 130px minmax(0, 1fr);
+        border-bottom: none;
+      }
+
+      .category-label {
+        border-bottom: 1px solid var(--color-table-border);
+
+        &.category-label-left,
+        &.category-label-right {
+          grid-column: 1;
+        }
+      }
+
+      .category-value {
+        overflow-wrap: anywhere;
+        border-bottom: 1px solid var(--color-table-border);
+
+        &.category-value-left,
+        &.category-value-right {
+          grid-column: 2;
+          border-right: none;
+        }
       }
     }
   }

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -1,0 +1,53 @@
+@use "@/assets/css/common";
+
+main {
+  // key-value ペアを2列グリッドで並べる説明リスト。
+  // dt が「項目名」、dd が「値」に対応し、4カラムのグリッドに配置される。
+  // 例: [Variant type] [SNV] [Ref / Alt] [A→T]
+  //     [Position]     [chr1:12345 (GRCh38)]
+  .variant-summary-list {
+    display: grid;
+
+    // max-content で各 dt 列をラベルの最大幅に自動調整する。
+    // 固定px だと "HGNC/Approved symbol" のような長いラベルが溢れるため。
+    grid-template-columns: max-content 1fr max-content 1fr;
+
+    // column-gap を使うと列間が空白トラックになり border-bottom が途切れる。
+    // 代わりに dd の padding-right でペア間の空きを作り、border を全幅で連続させる。
+    width: 100%;
+    margin: 0;
+    font-family: "Roboto Condensed", sans-serif;
+
+    dt,
+    dd {
+      // align-self はデフォルトの stretch のままにして、セルをロー全体の高さに引き伸ばす。
+      // align-self: center にすると各セルが内容高さで縮み、border-bottom がバラバラな位置に引かれる。
+      display: flex;
+      align-items: center;
+      padding: 3px 0;
+      line-height: 1.2;
+      border-bottom: 1px solid var(--color-table-border);
+    }
+
+    dt {
+      padding-left: 10px;
+      font-size: 12px;
+      font-weight: bold;
+      color: var(--color-black);
+    }
+
+    dd {
+      // ブラウザデフォルトの margin-left をリセットする
+      padding-right: 10px;
+      padding-left: 12px;
+      margin: 0;
+      font-size: 14px;
+      color: var(--color-black);
+      white-space: nowrap;
+
+      .chromosome {
+        font-weight: bold;
+      }
+    }
+  }
+}

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -76,6 +76,9 @@ main {
 
       .source {
         display: inline-block;
+        max-width: 100%;
+        vertical-align: top;
+        overflow-wrap: anywhere;
       }
 
       .source-separator {
@@ -90,6 +93,7 @@ main {
 
       .source-link {
         color: var(--color-key-dark2);
+        overflow-wrap: anywhere;
 
         &:hover {
           color: var(--color-key-dark1);
@@ -109,6 +113,10 @@ main {
 
       .not-available {
         color: var(--color-gray);
+      }
+
+      .source-value {
+        overflow-wrap: anywhere;
       }
     }
 

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -23,7 +23,6 @@ main {
       color: var(--color-black);
       text-align: left;
       white-space: nowrap;
-      border-right: 1px solid var(--color-table-border);
 
       &.category-label-left {
         grid-column: 1;
@@ -66,6 +65,7 @@ main {
 
       &.category-value-left {
         grid-column: 2;
+        border-right: 1px solid var(--color-table-border);
       }
 
       &.category-value-right {

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -47,11 +47,11 @@ main {
       .caret-down {
         display: inline-block;
         margin-left: 4px;
-        font-family: FontAwesome;
+        font-family: "Font Awesome 7 Free";
         font-size: 10px;
 
         &::before {
-          content: var(--char-arrow-down-long);
+          content: var(--icon-arrow-down);
         }
       }
     }
@@ -99,11 +99,11 @@ main {
       .external-link-icon {
         display: inline-block;
         margin-left: 3px;
-        font-family: FontAwesome;
+        font-family: "Font Awesome 7 Free";
         font-size: 10px;
 
         &::before {
-          content: var(--char-external-link);
+          content: var(--icon-arrow-up-right-from-square);
         }
       }
 

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -61,7 +61,7 @@ main {
       margin: 0;
       font-size: 14px;
       line-height: 1.2;
-      color: #444;
+      color: var(--color-black);
       text-align: left;
       white-space: normal;
 
@@ -161,7 +161,7 @@ main {
     margin: 0;
     font-family: "Roboto Condensed", sans-serif;
     font-size: 14px;
-    color: #444;
+    color: var(--color-black);
     text-align: center;
   }
 }

--- a/stanzas/variant-links/templates/stanza.html.hbs
+++ b/stanzas/variant-links/templates/stanza.html.hbs
@@ -1,37 +1,69 @@
 {{#with error}}
   <div class="alert alert-danger">{{message}}</div>
 {{else}}
-  <div>
-    {{#with result}}
-      <dl class="variant-summary-list">
-        <dt>Position</dt>
-        <dd>
-          <span class="chromosome">{{chr}}</span>:<span class="position">{{position}}</span>
-          <span class="assembly">({{assembly}})</span>
-        </dd>
+  {{#if result}}
+    <dl class="variant-links-list">
+      {{#each result}}
+        <div class="category-row">
+          {{#with left}}
+            <dt class="category-label category-label-left">
+              {{#if anchor}}
+                <a class="category-link" href="{{anchor}}">{{label}}<span class="caret-down"></span></a>
+              {{else}}
+                {{label}}
+              {{/if}}
+            </dt>
+            <dd class="category-value category-value-left">
+              {{#each sources}}
+                <span class="source">
+                  <strong class="source-name">{{name}}</strong>
+                  {{#if url}}
+                    <a
+                      class="source-link"
+                      href="{{url}}"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >{{value}}<span class="external-link-icon"></span></a>
+                  {{else}}
+                    <span class="not-available">N/A</span>
+                  {{/if}}
+                </span>{{#unless @last}}, {{/unless}}
+              {{/each}}
+            </dd>
+          {{/with}}
 
-        <dt>Ref / Alt</dt>
-        <dd>
-          <div class="ref-alt">
-            <span class="ref" data-sum="{{ref_length}}">{{ref}}</span><span class="arrow"></span><span
-              class="alt" data-sum="{{alt_length}}">{{alt}}</span>
-          </div>
-        </dd>
-
-        {{#if ../gene}}
-          <dt>HGNC/Approved symbol</dt>
-          <dd>
-            {{#if ../gene.hgnc_url}}
-              <a href="{{../gene.hgnc_url}}">{{../gene.symbol}}</a>
-            {{else}}
-              {{../gene.symbol}}
-            {{/if}}
-          </dd>
-
-          <dt>HGNC/Approved name</dt>
-          <dd>{{../gene.approved_name}}</dd>
-        {{/if}}
-      </dl>
-    {{/with}}
-  </div>
+          {{#if right}}
+            {{#with right}}
+              <dt class="category-label category-label-right">
+                {{#if anchor}}
+                  <a class="category-link" href="{{anchor}}">{{label}}<span class="caret-down"></span></a>
+                {{else}}
+                  {{label}}
+                {{/if}}
+              </dt>
+              <dd class="category-value category-value-right">
+                {{#each sources}}
+                  <span class="source">
+                    <strong class="source-name">{{name}}</strong>
+                    {{#if url}}
+                      <a
+                        class="source-link"
+                        href="{{url}}"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >{{value}}<span class="external-link-icon"></span></a>
+                    {{else}}
+                      <span class="not-available">N/A</span>
+                    {{/if}}
+                  </span>{{#unless @last}}, {{/unless}}
+                {{/each}}
+              </dd>
+            {{/with}}
+          {{/if}}
+        </div>
+      {{/each}}
+    </dl>
+  {{else}}
+    <p class="variant-links-no-data">No data</p>
+  {{/if}}
 {{/with}}

--- a/stanzas/variant-links/templates/stanza.html.hbs
+++ b/stanzas/variant-links/templates/stanza.html.hbs
@@ -1,0 +1,37 @@
+{{#with error}}
+  <div class="alert alert-danger">{{message}}</div>
+{{else}}
+  <div>
+    {{#with result}}
+      <dl class="variant-summary-list">
+        <dt>Position</dt>
+        <dd>
+          <span class="chromosome">{{chr}}</span>:<span class="position">{{position}}</span>
+          <span class="assembly">({{assembly}})</span>
+        </dd>
+
+        <dt>Ref / Alt</dt>
+        <dd>
+          <div class="ref-alt">
+            <span class="ref" data-sum="{{ref_length}}">{{ref}}</span><span class="arrow"></span><span
+              class="alt" data-sum="{{alt_length}}">{{alt}}</span>
+          </div>
+        </dd>
+
+        {{#if ../gene}}
+          <dt>HGNC/Approved symbol</dt>
+          <dd>
+            {{#if ../gene.hgnc_url}}
+              <a href="{{../gene.hgnc_url}}">{{../gene.symbol}}</a>
+            {{else}}
+              {{../gene.symbol}}
+            {{/if}}
+          </dd>
+
+          <dt>HGNC/Approved name</dt>
+          <dd>{{../gene.approved_name}}</dd>
+        {{/if}}
+      </dl>
+    {{/with}}
+  </div>
+{{/with}}

--- a/stanzas/variant-links/templates/stanza.html.hbs
+++ b/stanzas/variant-links/templates/stanza.html.hbs
@@ -25,7 +25,11 @@
                       rel="noopener noreferrer"
                     >{{value}}<span class="external-link-icon"></span></a>
                   {{else}}
-                    <span class="not-available">N/A</span>
+                    {{#if available}}
+                      <span class="source-value">{{value}}</span>
+                    {{else}}
+                      <span class="not-available">N/A</span>
+                    {{/if}}
                   {{/if}}
                 </span>{{#unless @last}}, {{/unless}}
               {{/each}}
@@ -53,7 +57,11 @@
                         rel="noopener noreferrer"
                       >{{value}}<span class="external-link-icon"></span></a>
                     {{else}}
-                      <span class="not-available">N/A</span>
+                      {{#if available}}
+                        <span class="source-value">{{value}}</span>
+                      {{else}}
+                        <span class="not-available">N/A</span>
+                      {{/if}}
                     {{/if}}
                   </span>{{#unless @last}}, {{/unless}}
                 {{/each}}

--- a/stanzas/variant-links/templates/stanza.html.hbs
+++ b/stanzas/variant-links/templates/stanza.html.hbs
@@ -16,6 +16,9 @@
             <dd class="category-value category-value-left">
               {{#each sources}}
                 <span class="source">
+                  {{#if dataset}}
+                    <span class="dataset-icon" data-dataset="{{dataset}}"></span>
+                  {{/if}}
                   <span class="source-name">{{name}}</span>
                   {{#if url}}
                     <a
@@ -49,6 +52,9 @@
               <dd class="category-value category-value-right">
                 {{#each sources}}
                   <span class="source">
+                    {{#if dataset}}
+                      <span class="dataset-icon" data-dataset="{{dataset}}"></span>
+                    {{/if}}
                     <span class="source-name">{{name}}</span>
                     {{#if url}}
                       <a

--- a/stanzas/variant-links/templates/stanza.html.hbs
+++ b/stanzas/variant-links/templates/stanza.html.hbs
@@ -31,7 +31,8 @@
                       <span class="not-available">N/A</span>
                     {{/if}}
                   {{/if}}
-                </span>{{#unless @last}}<span class="source-separator">, </span>{{/unless}}
+                  {{#unless @last}}<span class="source-separator">, </span>{{/unless}}
+                </span>
               {{/each}}
             </dd>
           {{/with}}
@@ -63,7 +64,8 @@
                         <span class="not-available">N/A</span>
                       {{/if}}
                     {{/if}}
-                  </span>{{#unless @last}}<span class="source-separator">, </span>{{/unless}}
+                    {{#unless @last}}<span class="source-separator">, </span>{{/unless}}
+                  </span>
                 {{/each}}
               </dd>
             {{/with}}

--- a/stanzas/variant-links/templates/stanza.html.hbs
+++ b/stanzas/variant-links/templates/stanza.html.hbs
@@ -16,7 +16,7 @@
             <dd class="category-value category-value-left">
               {{#each sources}}
                 <span class="source">
-                  <strong class="source-name">{{name}}</strong>
+                  <span class="source-name">{{name}}</span>
                   {{#if url}}
                     <a
                       class="source-link"
@@ -31,7 +31,7 @@
                       <span class="not-available">N/A</span>
                     {{/if}}
                   {{/if}}
-                </span>{{#unless @last}}, {{/unless}}
+                </span>{{#unless @last}}<span class="source-separator">, </span>{{/unless}}
               {{/each}}
             </dd>
           {{/with}}
@@ -48,7 +48,7 @@
               <dd class="category-value category-value-right">
                 {{#each sources}}
                   <span class="source">
-                    <strong class="source-name">{{name}}</strong>
+                    <span class="source-name">{{name}}</span>
                     {{#if url}}
                       <a
                         class="source-link"
@@ -63,7 +63,7 @@
                         <span class="not-available">N/A</span>
                       {{/if}}
                     {{/if}}
-                  </span>{{#unless @last}}, {{/unless}}
+                  </span>{{#unless @last}}<span class="source-separator">, </span>{{/unless}}
                 {{/each}}
               </dd>
             {{/with}}

--- a/stanzas/variant-mgend/README.md
+++ b/stanzas/variant-mgend/README.md
@@ -8,6 +8,6 @@
 | --- | --- | --- | --- |
 | `tgv_id` | No | `tgv6784522` | TogoVar ID。`variant` が無い場合に必要です。 |
 | `variant` | No | `1-12345-A-T` | VCF表記 `CHROM-POS-REF-ALT` のバリアント。`tgv_id` が無い場合に必要です。 |
-| `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar variant search API URL。 |
+| `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar API base URL または `/api/search/variant` endpoint。 |
 
 `tgv_id` と `variant` の両方が指定された場合は `tgv_id` を優先します。

--- a/stanzas/variant-mgend/README.md
+++ b/stanzas/variant-mgend/README.md
@@ -1,3 +1,13 @@
 # Variant / MGeND
 
-Stanza description goes here. Edit `stanzas/variant-mgend/README.md` to update.
+指定したバリアントに紐づく MGeND の臨床的意義と疾患条件を表示する stanza です。
+
+## Parameters
+
+| Key | Required | Example | Description |
+| --- | --- | --- | --- |
+| `tgv_id` | No | `tgv6784522` | TogoVar ID。`variant` が無い場合に必要です。 |
+| `variant` | No | `1-12345-A-T` | VCF表記 `CHROM-POS-REF-ALT` のバリアント。`tgv_id` が無い場合に必要です。 |
+| `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar variant search API URL。 |
+
+`tgv_id` と `variant` の両方が指定された場合は `tgv_id` を優先します。

--- a/stanzas/variant-mgend/index.ts
+++ b/stanzas/variant-mgend/index.ts
@@ -62,7 +62,7 @@ function buildConditionRows(apiResponse: TogoVarApiResponse): ConditionRow[] {
   const conditionRows: ConditionRow[] = [];
 
   apiResponse.data.forEach((variantData) => {
-    const mgendLink = variantData.external_links.mgend?.[0];
+    const mgendLink = variantData.external_links?.mgend?.[0];
     if (!mgendLink) return;
 
     variantData.significance.forEach((significanceEntry) => {

--- a/stanzas/variant-mgend/index.ts
+++ b/stanzas/variant-mgend/index.ts
@@ -6,7 +6,15 @@ import {
 } from "@/lib/constants";
 import { escapeHtml } from "@/lib/html";
 import { rowSpanize } from "@/lib/table";
+import { describeVariantIdentifier } from "@/lib/sparqlist";
+import {
+  fetchVariantDataById,
+  fetchVariantDataByLocation,
+  requireVariantData,
+} from "@/lib/togovar-variant";
 import type { TogoVarApiResponse, DiseaseCondition } from "@/lib/types";
+import { parseVariantParam } from "@/lib/variant";
+import type { ParsedVariant } from "@/lib/variant";
 
 // ============================================================
 // このスタンザ固有の型定義
@@ -28,6 +36,12 @@ interface ConditionRow {
   interpretationClass: string;
   /** 解釈ラベル（CLINICAL_SIGNIFICANCEのlabel） */
   interpretationLabel: string | null;
+}
+
+interface VariantMGeNDParams {
+  tgv_id?: string;
+  variant?: string;
+  "data-url"?: string;
 }
 
 // ============================================================
@@ -150,29 +164,36 @@ export default class VariantMGeND extends Stanza {
   async render() {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
-    const { "data-url": dataUrl, tgv_id } = this.params;
+    const params = this.params as VariantMGeNDParams;
+    const { "data-url": dataUrl, tgv_id } = params;
+    const parsedVariant = parseVariantParam(params.variant);
 
     try {
-      const response = await fetch(dataUrl, {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ query: { id: [tgv_id] } }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`${dataUrl} returned status ${response.status}`);
+      if (!dataUrl) {
+        throw new Error("data-url parameter is required");
+      }
+      if (!tgv_id && !parsedVariant) {
+        throw new Error("tgv_id or variant parameter is required");
       }
 
-      const apiResponse: TogoVarApiResponse = await response.json();
+      const apiResponse: TogoVarApiResponse = tgv_id
+        ? await fetchVariantDataById(dataUrl, tgv_id)
+        : await fetchVariantDataByLocation(
+            dataUrl,
+            parsedVariant as ParsedVariant,
+          );
+      const variantData = requireVariantData(
+        apiResponse,
+        tgv_id,
+        parsedVariant,
+        describeVariantIdentifier(params),
+      );
 
       this.renderTemplate({
         template: "stanza.html.hbs",
         parameters: {
           params: this.params,
-          result: buildConditionRows(apiResponse),
+          result: buildConditionRows({ data: [variantData] }),
         },
       });
     } catch (error) {

--- a/stanzas/variant-mgend/index.ts
+++ b/stanzas/variant-mgend/index.ts
@@ -13,7 +13,7 @@ import {
   requireVariantData,
 } from "@/lib/togovar-variant";
 import type { TogoVarApiResponse, DiseaseCondition } from "@/lib/types";
-import { parseVariantParam } from "@/lib/variant";
+import { assertValidVariantIdentifier, parseVariantParam } from "@/lib/variant";
 import type { ParsedVariant } from "@/lib/variant";
 
 // ============================================================
@@ -172,9 +172,7 @@ export default class VariantMGeND extends Stanza {
       if (!dataUrl) {
         throw new Error("data-url parameter is required");
       }
-      if (!tgv_id && !parsedVariant) {
-        throw new Error("tgv_id or variant parameter is required");
-      }
+      assertValidVariantIdentifier(tgv_id, params.variant, parsedVariant);
 
       const apiResponse: TogoVarApiResponse = tgv_id
         ? await fetchVariantDataById(dataUrl, tgv_id)

--- a/stanzas/variant-mgend/metadata.json
+++ b/stanzas/variant-mgend/metadata.json
@@ -30,7 +30,7 @@
     {
       "stanza:key": "data-url",
       "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
-      "stanza:description": "TogoVar variant search API URL",
+      "stanza:description": "TogoVar API base URL or variant search API URL",
       "stanza:required": true
     }
   ],

--- a/stanzas/variant-mgend/metadata.json
+++ b/stanzas/variant-mgend/metadata.json
@@ -13,18 +13,25 @@
   "stanza:address": "",
   "stanza:contributor": [],
   "stanza:created": "2024-11-14",
-  "stanza:updated": "2024-11-14",
+  "stanza:updated": "2026-08-12",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv6784522",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "data-url",
       "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
-      "stanza:description": "URL"
+      "stanza:description": "TogoVar variant search API URL",
+      "stanza:required": true
     }
   ],
   "stanza:about-link-placement": "bottom-right",

--- a/stanzas/variant-other-overlapping-variants/index.js
+++ b/stanzas/variant-other-overlapping-variants/index.js
@@ -6,8 +6,8 @@ import {buildIdentifierQueryString} from "@/lib/sparqlist";
 import {normalizeChromosome, parseVariantParam} from "@/lib/variant";
 
 const isInputVariant = (record, params) => {
-  if (params.tgv_id && record.id === params.tgv_id) {
-    return true;
+  if (params.tgv_id) {
+    return record.id === params.tgv_id;
   }
 
   const variant = parseVariantParam(params.variant);

--- a/stanzas/variant-other-overlapping-variants/index.js
+++ b/stanzas/variant-other-overlapping-variants/index.js
@@ -17,8 +17,8 @@ const isInputVariant = (record, params) => {
 
   return normalizeChromosome(record.chromosome) === normalizeChromosome(variant.chromosome) &&
     String(record.position) === variant.position &&
-    String(record.reference) === variant.reference &&
-    String(record.alternate) === variant.alternate;
+    String(record.reference).toUpperCase() === variant.reference &&
+    String(record.alternate).toUpperCase() === variant.alternate;
 };
 
 export default class VariantSummary extends Stanza {

--- a/stanzas/variant-other-overlapping-variants/index.js
+++ b/stanzas/variant-other-overlapping-variants/index.js
@@ -2,21 +2,8 @@ import Stanza from "togostanza/stanza";
 
 import {transformRecord} from "@/lib/display";
 import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
-
-const parseVariantParam = (variant) => {
-  if (!variant) {
-    return undefined;
-  }
-
-  const [chromosome, position, reference, alternate] = variant.split("-");
-  if (!chromosome || !position || !reference || !alternate) {
-    return undefined;
-  }
-
-  return {chromosome, position, reference, alternate};
-};
-
-const normalizeChromosome = (chromosome) => String(chromosome ?? "").replace(/^chr/i, "");
+import {buildIdentifierQueryString} from "@/lib/sparqlist";
+import {normalizeChromosome, parseVariantParam} from "@/lib/variant";
 
 const isInputVariant = (record, params) => {
   if (params.tgv_id && record.id === params.tgv_id) {
@@ -40,10 +27,7 @@ export default class VariantSummary extends Stanza {
 
     // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
     // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
-    const queryString = new URLSearchParams({
-      tgv_id: this.params?.tgv_id ?? "",
-      variant: this.params?.variant ?? "",
-    }).toString();
+    const queryString = buildIdentifierQueryString(this.params ?? {});
     const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_other_alternative_alleles?${queryString}`)
 
     const r = await fetch(sparqlist, {

--- a/stanzas/variant-other-overlapping-variants/index.js
+++ b/stanzas/variant-other-overlapping-variants/index.js
@@ -3,6 +3,37 @@ import Stanza from "togostanza/stanza";
 import {transformRecord} from "@/lib/display";
 import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
 
+const parseVariantParam = (variant) => {
+  if (!variant) {
+    return undefined;
+  }
+
+  const [chromosome, position, reference, alternate] = variant.split("-");
+  if (!chromosome || !position || !reference || !alternate) {
+    return undefined;
+  }
+
+  return {chromosome, position, reference, alternate};
+};
+
+const normalizeChromosome = (chromosome) => String(chromosome ?? "").replace(/^chr/i, "");
+
+const isInputVariant = (record, params) => {
+  if (params.tgv_id && record.id === params.tgv_id) {
+    return true;
+  }
+
+  const variant = parseVariantParam(params.variant);
+  if (!variant) {
+    return false;
+  }
+
+  return normalizeChromosome(record.chromosome) === normalizeChromosome(variant.chromosome) &&
+    String(record.position) === variant.position &&
+    String(record.reference) === variant.reference &&
+    String(record.alternate) === variant.alternate;
+};
+
 export default class VariantSummary extends Stanza {
   async render() {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
@@ -26,7 +57,7 @@ export default class VariantSummary extends Stanza {
       }
       throw new Error(sparqlist + " returns status " + res.status);
     }).then(json => {
-      let records = json.data ? json.data.filter(x => x.id !== this.params.tgv_id) : [];
+      let records = json.data ? json.data.filter(x => !isInputVariant(x, this.params)) : [];
 
       records.forEach(record => transformRecord(record, this.params.assembly));
 

--- a/stanzas/variant-other-overlapping-variants/index.js
+++ b/stanzas/variant-other-overlapping-variants/index.js
@@ -7,7 +7,13 @@ export default class VariantSummary extends Stanza {
   async render() {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
-    const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_other_alternative_alleles?tgv_id=${this.params.tgv_id}`)
+    // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
+    // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
+    const queryString = new URLSearchParams({
+      tgv_id: this.params?.tgv_id ?? "",
+      variant: this.params?.variant ?? "",
+    }).toString();
+    const sparqlist = (this.params?.sparqlist || "/sparqlist").concat(`/api/variant_other_alternative_alleles?${queryString}`)
 
     const r = await fetch(sparqlist, {
       method: "GET",

--- a/stanzas/variant-other-overlapping-variants/metadata.json
+++ b/stanzas/variant-other-overlapping-variants/metadata.json
@@ -13,13 +13,19 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-04-22",
-  "stanza:updated": "2022-04-15",
+  "stanza:updated": "2026-07-27",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv122011872",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "assembly",

--- a/stanzas/variant-publication/README.md
+++ b/stanzas/variant-publication/README.md
@@ -9,6 +9,6 @@
 | `tgv_id` | No | `tgv29245294` | TogoVar ID。`variant` が無い場合に必要です。 |
 | `variant` | No | `1-12345-A-T` | VCF表記 `CHROM-POS-REF-ALT` のバリアント。`tgv_id` が無い場合に使えます。 |
 | `sparqlist` | No | `https://grch38.togovar.org/sparqlist` | SPARQList URL。 |
-| `data-url` | No | `https://stg-grch38.togovar.org/api/search/variant` | `variant` のみ指定時に TogoVar ID へ解決するための TogoVar variant search API URL。 |
+| `data-url` | No | `https://stg-grch38.togovar.org/api/search/variant` | `variant` のみ指定時に TogoVar ID へ解決するための URL。TogoVar API base URL または `/api/search/variant` endpoint を指定できます。 |
 
 `tgv_id` と `variant` の両方が指定された場合は `tgv_id` を優先します。

--- a/stanzas/variant-publication/README.md
+++ b/stanzas/variant-publication/README.md
@@ -1,3 +1,14 @@
 # Variant / Publication
 
-Stanza description goes here. Edit `stanzas/variant-publication/README.md` to update.
+指定したバリアントに紐づく文献情報を表示する stanza です。
+
+## Parameters
+
+| Key | Required | Example | Description |
+| --- | --- | --- | --- |
+| `tgv_id` | No | `tgv29245294` | TogoVar ID。`variant` が無い場合に必要です。 |
+| `variant` | No | `1-12345-A-T` | VCF表記 `CHROM-POS-REF-ALT` のバリアント。`tgv_id` が無い場合に使えます。 |
+| `sparqlist` | No | `https://grch38.togovar.org/sparqlist` | SPARQList URL。 |
+| `data-url` | No | `https://stg-grch38.togovar.org/api/search/variant` | `variant` のみ指定時に TogoVar ID へ解決するための TogoVar variant search API URL。 |
+
+`tgv_id` と `variant` の両方が指定された場合は `tgv_id` を優先します。

--- a/stanzas/variant-publication/index.js
+++ b/stanzas/variant-publication/index.js
@@ -2,6 +2,7 @@ import Stanza from "@/lib/stanza";
 import {unwrapValueFromBinding} from "togostanza/utils";
 
 import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
+import {buildIdentifierQueryString} from "@/lib/sparqlist";
 
 const RS_PREFIX = "http://identifiers.org/dbsnp/";
 
@@ -11,10 +12,7 @@ export default class VariantPublication extends Stanza {
 
     // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
     // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
-    const queryString = new URLSearchParams({
-      tgv_id: this.params.tgv_id ?? "",
-      variant: this.params.variant ?? "",
-    }).toString();
+    const queryString = buildIdentifierQueryString(this.params);
     const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?${queryString}`);
 
     const r = await fetch(sparqlist, {

--- a/stanzas/variant-publication/index.js
+++ b/stanzas/variant-publication/index.js
@@ -4,7 +4,7 @@ import {unwrapValueFromBinding} from "togostanza/utils";
 import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
 import {buildIdentifierQueryString, describeVariantIdentifier} from "@/lib/sparqlist";
 import {fetchVariantDataByIdentifier} from "@/lib/togovar-variant";
-import {parseVariantParam} from "@/lib/variant";
+import {assertValidVariantIdentifier, parseVariantParam} from "@/lib/variant";
 
 const RS_PREFIX = "http://identifiers.org/dbsnp/";
 
@@ -16,9 +16,7 @@ export default class VariantPublication extends Stanza {
     const parsedVariant = parseVariantParam(params.variant);
 
     const r = await Promise.resolve().then(async () => {
-      if (!params.tgv_id && !parsedVariant) {
-        throw new Error("tgv_id or variant parameter is required");
-      }
+      assertValidVariantIdentifier(params.tgv_id, params.variant, parsedVariant);
 
       let tgvId = params.tgv_id;
       if (!tgvId) {

--- a/stanzas/variant-publication/index.js
+++ b/stanzas/variant-publication/index.js
@@ -2,7 +2,9 @@ import Stanza from "@/lib/stanza";
 import {unwrapValueFromBinding} from "togostanza/utils";
 
 import {ROBOTO_CONDENSED_CSS_URL} from "@/lib/constants";
-import {buildIdentifierQueryString} from "@/lib/sparqlist";
+import {buildIdentifierQueryString, describeVariantIdentifier} from "@/lib/sparqlist";
+import {fetchVariantDataByIdentifier} from "@/lib/togovar-variant";
+import {parseVariantParam} from "@/lib/variant";
 
 const RS_PREFIX = "http://identifiers.org/dbsnp/";
 
@@ -10,21 +12,44 @@ export default class VariantPublication extends Stanza {
   async render() {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
-    // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
-    // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
-    const queryString = buildIdentifierQueryString(this.params);
-    const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?${queryString}`);
+    const params = this.params ?? {};
+    const parsedVariant = parseVariantParam(params.variant);
 
-    const r = await fetch(sparqlist, {
-      method: "GET",
-      headers: {
-        "Accept": "application/json",
-      },
+    const r = await Promise.resolve().then(async () => {
+      if (!params.tgv_id && !parsedVariant) {
+        throw new Error("tgv_id or variant parameter is required");
+      }
+
+      let tgvId = params.tgv_id;
+      if (!tgvId) {
+        if (!params["data-url"]) {
+          throw new Error("data-url parameter is required when variant is given without tgv_id");
+        }
+
+        const variantData = await fetchVariantDataByIdentifier(
+          params["data-url"],
+          tgvId,
+          parsedVariant,
+          describeVariantIdentifier(params),
+        );
+        tgvId = variantData.id;
+      }
+
+      // tgv2rs は variant を解釈しないため、必ず解決済みの tgv_id だけを渡す。
+      const queryString = buildIdentifierQueryString({ tgv_id: tgvId });
+      const sparqlist = (params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?${queryString}`);
+
+      return fetch(sparqlist, {
+        method: "GET",
+        headers: {
+          "Accept": "application/json",
+        },
+      });
     }).then(res => {
       if (res.ok) {
         return res.json();
       }
-      throw new Error(sparqlist + " returns status " + res.status);
+      throw new Error("tgv2rs returns status " + res.status);
     }).then(json => {
       return unwrapValueFromBinding(json)[0];
     }).then(result => {
@@ -32,7 +57,7 @@ export default class VariantPublication extends Stanza {
         return;
       }
 
-      const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/variant_publication?rs=${result.rs.replace(RS_PREFIX, "")}`);
+      const sparqlist = (params.sparqlist || "/sparqlist").concat(`/api/variant_publication?rs=${result.rs.replace(RS_PREFIX, "")}`);
 
       return fetch(sparqlist, {
         method: "GET",

--- a/stanzas/variant-publication/index.js
+++ b/stanzas/variant-publication/index.js
@@ -75,7 +75,7 @@ export default class VariantPublication extends Stanza {
           }, {}))
         }
       }).catch(e => ({ error: { message: e.message } }));
-    });
+    }).catch(e => ({error: {message: e.message}}));
 
     const sources = [
       new URL("./assets/vendor/jquery/3.6.0/jquery.min.js", import.meta.url),

--- a/stanzas/variant-publication/index.js
+++ b/stanzas/variant-publication/index.js
@@ -9,7 +9,13 @@ export default class VariantPublication extends Stanza {
   async render() {
     this.importWebFontCSS(ROBOTO_CONDENSED_CSS_URL);
 
-    const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?tgv_id=${this.params.tgv_id}`);
+    // tgv_id が無いバリアント（TogoVar未登録）は variant(CHROM-POS-REF-ALT) で解決する。
+    // sparqlist側は tgv_id があれば優先し、無ければ variant を使う。
+    const queryString = new URLSearchParams({
+      tgv_id: this.params.tgv_id ?? "",
+      variant: this.params.variant ?? "",
+    }).toString();
+    const sparqlist = (this.params.sparqlist || "/sparqlist").concat(`/api/tgv2rs?${queryString}`);
 
     const r = await fetch(sparqlist, {
       method: "GET",

--- a/stanzas/variant-publication/metadata.json
+++ b/stanzas/variant-publication/metadata.json
@@ -13,13 +13,19 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-04-22",
-  "stanza:updated": "2022-04-15",
+  "stanza:updated": "2026-07-27",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv29245294",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "sparqlist",

--- a/stanzas/variant-publication/metadata.json
+++ b/stanzas/variant-publication/metadata.json
@@ -36,7 +36,7 @@
     {
       "stanza:key": "data-url",
       "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
-      "stanza:description": "TogoVar variant search API URL (required when variant is given without tgv_id)",
+      "stanza:description": "TogoVar API base URL or variant search API URL (required when variant is given without tgv_id)",
       "stanza:required": false
     }
   ],

--- a/stanzas/variant-publication/metadata.json
+++ b/stanzas/variant-publication/metadata.json
@@ -13,7 +13,7 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-04-22",
-  "stanza:updated": "2026-07-27",
+  "stanza:updated": "2026-08-12",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
@@ -31,6 +31,12 @@
       "stanza:key": "sparqlist",
       "stanza:example": "https://grch38.togovar.org/sparqlist",
       "stanza:description": "SPARQList URL",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "data-url",
+      "stanza:example": "https://stg-grch38.togovar.org/api/search/variant",
+      "stanza:description": "TogoVar variant search API URL (required when variant is given without tgv_id)",
       "stanza:required": false
     }
   ],

--- a/stanzas/variant-summary/index.ts
+++ b/stanzas/variant-summary/index.ts
@@ -4,9 +4,7 @@ import * as display from "@/lib/display";
 import { ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
 import {
   buildSparqlistApiUrl,
-  describeVariantIdentifier,
   fetchSparqlBindings,
-  requireFirstBinding,
 } from "@/lib/sparqlist";
 import type {
   SparqlistStanzaParams,
@@ -140,10 +138,15 @@ export default class VariantSummary extends Stanza {
       const summaryApiUrl = buildSparqlistApiUrl("variant_summary", params);
       const bindings =
         await fetchSparqlBindings<VariantSummarySparqlBinding>(summaryApiUrl);
-      const firstBinding = requireFirstBinding(
-        bindings,
-        `Variant not found for ${describeVariantIdentifier(params)}`,
-      );
+      const firstBinding = bindings[0];
+
+      if (!firstBinding) {
+        this.renderTemplate({
+          template: "stanza.html.hbs",
+          parameters: templateParams,
+        });
+        return;
+      }
 
       templateParams.result =
         convertSummaryBindingToDisplayData(firstBinding);

--- a/stanzas/variant-summary/index.ts
+++ b/stanzas/variant-summary/index.ts
@@ -4,6 +4,7 @@ import * as display from "@/lib/display";
 import { ROBOTO_CONDENSED_CSS_URL } from "@/lib/constants";
 import {
   buildSparqlistApiUrl,
+  describeVariantIdentifier,
   fetchSparqlBindings,
   requireFirstBinding,
 } from "@/lib/sparqlist";
@@ -141,7 +142,7 @@ export default class VariantSummary extends Stanza {
         await fetchSparqlBindings<VariantSummarySparqlBinding>(summaryApiUrl);
       const firstBinding = requireFirstBinding(
         bindings,
-        `Variant not found for ${params.tgv_id}`,
+        `Variant not found for ${describeVariantIdentifier(params)}`,
       );
 
       templateParams.result =

--- a/stanzas/variant-summary/metadata.json
+++ b/stanzas/variant-summary/metadata.json
@@ -13,13 +13,19 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-04-22",
-  "stanza:updated": "2026-07-06",
+  "stanza:updated": "2026-07-27",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv219804",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "sparqlist",

--- a/stanzas/variant-summary/style.scss
+++ b/stanzas/variant-summary/style.scss
@@ -8,9 +8,9 @@ main {
   .variant-summary-list {
     display: grid;
 
-    // variant-links と同じ列幅にして、左右ペアの境界線を常に全体幅の50%に揃える。
-    // 左右それぞれで「dt固定幅 + dd可変幅 = 50%」になるようにしている。
-    grid-template-columns: 130px calc(50% - 130px) 120px calc(50% - 120px);
+    // max-content で各 dt 列をラベルの最大幅に自動調整する。
+    // 固定px だと "HGNC/Approved symbol" のような長いラベルが溢れるため。
+    grid-template-columns: max-content 1fr max-content 1fr;
 
     // column-gap を使うと列間が空白トラックになり border-bottom が途切れる。
     // 代わりに dd の padding-right でペア間の空きを作り、border を全幅で連続させる。
@@ -48,22 +48,14 @@ main {
       .chromosome {
         font-weight: bold;
       }
-
-      &:nth-of-type(odd) {
-        border-right: 1px solid var(--color-table-border);
-      }
     }
 
     @media (width <= 580px) {
-      grid-template-columns: 130px minmax(0, 1fr);
+      grid-template-columns: max-content minmax(0, 1fr);
 
       dd {
         overflow-wrap: anywhere;
         white-space: normal;
-
-        &:nth-of-type(odd) {
-          border-right: none;
-        }
       }
     }
   }

--- a/stanzas/variant-summary/style.scss
+++ b/stanzas/variant-summary/style.scss
@@ -8,9 +8,9 @@ main {
   .variant-summary-list {
     display: grid;
 
-    // max-content で各 dt 列をラベルの最大幅に自動調整する。
-    // 固定px だと "HGNC/Approved symbol" のような長いラベルが溢れるため。
-    grid-template-columns: 150px calc(50% - 150px) 120px calc(50% - 120px);
+    // variant-links と同じ列幅にして、左右ペアの境界線を常に全体幅の50%に揃える。
+    // 左右それぞれで「dt固定幅 + dd可変幅 = 50%」になるようにしている。
+    grid-template-columns: 130px calc(50% - 130px) 120px calc(50% - 120px);
 
     // column-gap を使うと列間が空白トラックになり border-bottom が途切れる。
     // 代わりに dd の padding-right でペア間の空きを作り、border を全幅で連続させる。
@@ -51,6 +51,19 @@ main {
 
       &:nth-of-type(odd) {
         border-right: 1px solid var(--color-table-border);
+      }
+    }
+
+    @media (width <= 580px) {
+      grid-template-columns: 130px minmax(0, 1fr);
+
+      dd {
+        overflow-wrap: anywhere;
+        white-space: normal;
+
+        &:nth-of-type(odd) {
+          border-right: none;
+        }
       }
     }
   }

--- a/stanzas/variant-summary/style.scss
+++ b/stanzas/variant-summary/style.scss
@@ -10,7 +10,7 @@ main {
 
     // max-content で各 dt 列をラベルの最大幅に自動調整する。
     // 固定px だと "HGNC/Approved symbol" のような長いラベルが溢れるため。
-    grid-template-columns: max-content 1fr max-content 1fr;
+    grid-template-columns: 150px calc(50% - 150px) 120px calc(50% - 120px);
 
     // column-gap を使うと列間が空白トラックになり border-bottom が途切れる。
     // 代わりに dd の padding-right でペア間の空きを作り、border を全幅で連続させる。

--- a/stanzas/variant-summary/style.scss
+++ b/stanzas/variant-summary/style.scss
@@ -48,6 +48,10 @@ main {
       .chromosome {
         font-weight: bold;
       }
+
+      &:nth-of-type(odd) {
+        border-right: 1px solid var(--color-table-border);
+      }
     }
 
     @media (width <= 580px) {
@@ -56,6 +60,10 @@ main {
       dd {
         overflow-wrap: anywhere;
         white-space: normal;
+
+        &:nth-of-type(odd) {
+          border-right: none;
+        }
       }
     }
   }

--- a/stanzas/variant-summary/style.scss
+++ b/stanzas/variant-summary/style.scss
@@ -48,6 +48,10 @@ main {
       .chromosome {
         font-weight: bold;
       }
+
+      &:nth-of-type(odd) {
+        border-right: 1px solid var(--color-table-border);
+      }
     }
   }
 }

--- a/stanzas/variant-summary/templates/stanza.html.hbs
+++ b/stanzas/variant-summary/templates/stanza.html.hbs
@@ -2,36 +2,38 @@
   <div class="alert alert-danger">{{message}}</div>
 {{else}}
   <div>
-    {{#with result}}
-      <dl class="variant-summary-list">
-        <dt>Position</dt>
-        <dd>
+    <dl class="variant-summary-list">
+      <dt>Position</dt>
+      <dd>
+        {{#with result}}
           <span class="chromosome">{{chr}}</span>:<span class="position">{{position}}</span>
           <span class="assembly">({{assembly}})</span>
-        </dd>
+        {{/with}}
+      </dd>
 
-        <dt>Ref / Alt</dt>
-        <dd>
+      <dt>Ref / Alt</dt>
+      <dd>
+        {{#with result}}
           <div class="ref-alt">
             <span class="ref" data-sum="{{ref_length}}">{{ref}}</span><span class="arrow"></span><span
               class="alt" data-sum="{{alt_length}}">{{alt}}</span>
           </div>
+        {{/with}}
+      </dd>
+
+      {{#if gene}}
+        <dt>HGNC/Approved symbol</dt>
+        <dd>
+          {{#if gene.hgnc_url}}
+            <a href="{{gene.hgnc_url}}">{{gene.symbol}}</a>
+          {{else}}
+            {{gene.symbol}}
+          {{/if}}
         </dd>
 
-        {{#if ../gene}}
-          <dt>HGNC/Approved symbol</dt>
-          <dd>
-            {{#if ../gene.hgnc_url}}
-              <a href="{{../gene.hgnc_url}}">{{../gene.symbol}}</a>
-            {{else}}
-              {{../gene.symbol}}
-            {{/if}}
-          </dd>
-
-          <dt>HGNC/Approved name</dt>
-          <dd>{{../gene.approved_name}}</dd>
-        {{/if}}
-      </dl>
-    {{/with}}
+        <dt>HGNC/Approved name</dt>
+        <dd>{{gene.approved_name}}</dd>
+      {{/if}}
+    </dl>
   </div>
 {{/with}}

--- a/stanzas/variant-transcript/metadata.json
+++ b/stanzas/variant-transcript/metadata.json
@@ -13,13 +13,19 @@
   "stanza:address": "daisuke.satoh@lifematics.co.jp",
   "stanza:contributor": [],
   "stanza:created": "2019-04-22",
-  "stanza:updated": "2026-07-06",
+  "stanza:updated": "2026-07-27",
   "stanza:parameter": [
     {
       "stanza:key": "tgv_id",
       "stanza:example": "tgv219804",
-      "stanza:description": "TogoVar ID",
-      "stanza:required": true
+      "stanza:description": "TogoVar ID (required if variant is not given)",
+      "stanza:required": false
+    },
+    {
+      "stanza:key": "variant",
+      "stanza:example": "1-12345-A-T",
+      "stanza:description": "Variant in VCF notation CHROM-POS-REF-ALT (required if tgv_id is not given)",
+      "stanza:required": false
     },
     {
       "stanza:key": "sparqlist",


### PR DESCRIPTION
## 概要

variant 詳細ページ向けに、新規 stanza `variant-links` を追加しました。
また、TogoVar ID (`tgv_id`) を持たない variant も表示できるよう、複数の variant 系 stanza で VCF representation (`CHROM-POS-REF-ALT`) の `variant` パラメータを受け取れるようにしました。

このため、対象 stanza の metadata / README / 入力解決処理の更新が入り、変更量が大きくなっています。

## 主な変更

- `variant-links` stanza を追加
  - ClinVar / MGeND / dbSNP / ToMMo / JoGo / gnomAD / SSCVDB / MoG+ へのリンクを表示
- `tgv_id` に加えて `variant=CHROM-POS-REF-ALT` での指定に対応
- TogoVar API を使う stanza では、`variant` を TogoVar ID に解決してから既存処理へ渡すように変更
- SPARQList を使う stanza では、`variant` パラメータを SPARQList endpoint へ渡せるよう metadata / 共通 URL 組み立てを更新
- malformed な `variant` に対して分かりやすいエラーメッセージを表示
- `variant-summary` で 200 OK かつ空結果の場合は、エラーではなく空欄表示に変更
- `variant-frequency` の No data 表示位置を修正

## 補足

変更量が多く見えますが、主な理由は以下です。

- 新規 `variant-links` stanza の追加
- `variant` fallback を複数 stanza で一貫させるための metadata / README 更新
- `tgv_id` 優先、`variant` fallback の挙動を共通 helper に寄せたため
- review で指摘された endpoint 差分や error handling を反映したため

## 確認

- `npm run typecheck` passed
- 変更対象ファイルの ESLint / stylelint passed
- `npm run validate` は既存の unrelated lint error により fail
  - `gene-protein-browser`
  - `gene-protein-structure`
  - `jogo-haplotype-explorer`

---
This pull request introduces support for handling variants that do not have a TogoVar ID (`tgv_id`) by allowing the use of a VCF-style `variant` parameter (CHROM-POS-REF-ALT) throughout the codebase. It also adds a new stanza, `variant-links`, for displaying external database links associated with a variant, and updates parameter documentation and metadata to reflect the new input method. Several utility functions and type definitions are added or updated to support these changes.

**Support for variant parameter and improved identifier handling:**

* Added support for a `variant` parameter (VCF notation) as an alternative to `tgv_id` in shared stanza parameters (`SparqlistStanzaParams`), allowing the display of variants not registered in TogoVar. The logic prioritizes `tgv_id` when both are present, matching the backend resolution strategy. [[1]](diffhunk://#diff-af9e5e8969ffd0322ef4acda0e127e2817951b9a0475cd9d9b6f86326f85d865L6-R15) [[2]](diffhunk://#diff-b396eefef4100b25425c3526d0226c26c2cbf18e159c3ff5b9c76c2ffc9fc5c3R5-R56)
* Introduced utility functions in `lib/variant.ts` to parse and normalize the `variant` parameter and handle chromosome notation differences.
* Updated all relevant stanzas (e.g., `variant-gene`, `variant-header`, `variant-genomic-context`) to use the new identifier query string builder, enabling consistent handling of both `tgv_id` and `variant`. [[1]](diffhunk://#diff-471c4ec3642b48b284eef216f5fc542ebc08e3d6c9786335d1656a4c8682a947R5-R14) [[2]](diffhunk://#diff-3d011139a441d6c947e16673ae655aa53d295201db1956a657de3396e29ee14dR6-R15) [[3]](diffhunk://#diff-2e10516be642c92a28e0f8f5a59f8d969cb5de11dffdf681667c5de6b97caeb2L5-R12)
* Improved error messages and identifier descriptions to use whichever identifier is available. [[1]](diffhunk://#diff-2e10516be642c92a28e0f8f5a59f8d969cb5de11dffdf681667c5de6b97caeb2L24-R27) [[2]](diffhunk://#diff-b396eefef4100b25425c3526d0226c26c2cbf18e159c3ff5b9c76c2ffc9fc5c3R5-R56)

**New stanza and UI improvements:**

* Added a new stanza, `variant-links`, including its README, metadata, and SCSS, to display external database links for a variant, supporting both `tgv_id` and `variant` as input. [[1]](diffhunk://#diff-c95766c42c5ba9076ef65d954c7572914c9f0728149b46e8844f3a2de71a6efdR1-R30) [[2]](diffhunk://#diff-6d5eeea0fb9941fac5fe93ce61494b1836ada7ca6fc37dd3e0b32b9f117e0733R1-R49) [[3]](diffhunk://#diff-5203f9d227ab62d06197e012bab762bb4527ee4979586c45375ec0b0fc0a50caR1-R167)
* Updated the `ExternalLinks` and `VariantData` types to include new link categories and variant fields needed for the new and existing stanzas.

**Documentation and metadata updates:**

* Updated the metadata for all affected stanzas to describe the new `variant` parameter, clarify the relationship between `tgv_id` and `variant`, and mark both as optional (but one required). [[1]](diffhunk://#diff-36798dd11c396987d7ba2c069af4ab6f8b4f76a4b70827a50aab6338455a9687L16-R28) [[2]](diffhunk://#diff-2b8d9e714e8e7c3828684abe3448152ed7b6722d5e0a482ce369a38884f04fc7L16-R28) [[3]](diffhunk://#diff-a2fe65c877f88d2e46ff2be129378beef73c2c32234882ee6cb51c67f3695911L16-R28) [[4]](diffhunk://#diff-89cc460ebb110bfe8fee5b91440dc99e8ce4dab33c14613da4d48f2ec36d82c2L16-R28)

**API utility enhancements:**

* Added functions to query the TogoVar API by either `tgv_id` or `variant` (via location), and to select the correct variant data from API responses, handling multi-allelic sites correctly.

These changes increase the flexibility and robustness of the system when handling variants, especially those not registered in TogoVar, and provide a more comprehensive and user-friendly interface for external database links.