### PR TITLE
feat: hide JoGo frequency for GRCh37 assembly

### DIFF
--- a/stanzas/variant-links/README.md
+++ b/stanzas/variant-links/README.md
@@ -9,7 +9,7 @@
 | `tgv_id` | No(`variant`未指定時は必須) | `tgv167913213` | TogoVar ID。 |
 | `variant` | No(`tgv_id`未指定時は必須) | `1-12345-A-T` | VCF表記(CHROM-POS-REF-ALT)のバリアント。TogoVar未登録で`tgv_id`を持たないバリアントを表示する場合に使う。両方指定時は`tgv_id`を優先する。 |
 | `data-url` | Yes | `https://stg-grch38.togovar.org/api/search/variant` | TogoVar API base URL または `/api/search/variant` endpoint。 |
-| `assembly` | No | `GRCh38` | TogoVar variant 座標の assembly。MoG+ は GRCh38 の場合だけ問い合わせます。未指定時は `data-url` / `sparqlist` から `GRCh38`/`GRCh37` を推定します。 |
+| `assembly` | No | `GRCh38` | TogoVar variant 座標の assembly。MoG+ は GRCh38 の場合だけ問い合わせます。JoGo は GRCh37 の場合は表示しません。未指定時は `data-url` / `sparqlist` から `GRCh38`/`GRCh37` を推定します。 |
 | `sparqlist` | No | `https://stg-grch38.togovar.org/sparqlist` | MoG+ cross species link を取得するSPARQList URL。未指定時は MoG+ を `N/A` と表示します。 |
 | `mogplus_ver` | No | `mogplus21` | MoG+ version。未指定時は `mogplus21` を使います。 |
 
@@ -26,6 +26,8 @@ SPARQList の `variant_mogplus` endpoint から取得します。`variant_mogplu
 座標は GRCh38 として扱われるため、`assembly` が `GRCh38` と解決できる場合だけ
 MoG+ を問い合わせます。`GRCh37` または assembly が解決できない場合は MoG+ を
 `N/A` と表示します。
+JoGo は GRCh38 のリンクとして扱うため、`assembly` が `GRCh37` と解決できる場合は
+Frequency 欄に表示しません。
 
 ```txt
 tgv_id=tgv167913213

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -283,9 +283,35 @@ const buildLinkCategoryRows = (
   variantData: VariantData,
   mogplusEntry: MogplusEntry | undefined,
   mogplusVersion: string,
+  sourceAssembly: string | undefined,
 ): LinkCategoryRow[] => {
   const externalLinks = (variantData.external_links ??
     {}) as VariantExternalLinks;
+  const frequencySources = [
+    buildSourceFromExternalLink(
+      "dbSNP",
+      firstExternalLink(externalLinks, "dbsnp"),
+    ),
+    buildSourceFromExternalLink(
+      "ToMMo",
+      firstExternalLink(externalLinks, "tommo"),
+      "tommo",
+    ),
+    ...(sourceAssembly === "GRCh37"
+      ? []
+      : [
+          buildSourceFromExternalLink(
+            "JoGo",
+            firstExternalLink(externalLinks, "jogo"),
+            "jogo",
+          ),
+        ]),
+    buildSourceFromExternalLink(
+      "gnomAD",
+      firstExternalLink(externalLinks, "gnomad"),
+      "gnomad",
+    ),
+  ];
 
   const categories = new Map<string, LinkCategory>([
     [
@@ -318,27 +344,7 @@ const buildLinkCategoryRows = (
       {
         label: "Frequency",
         anchor: CATEGORY_ANCHORS.Frequency,
-        sources: [
-          buildSourceFromExternalLink(
-            "dbSNP",
-            firstExternalLink(externalLinks, "dbsnp"),
-          ),
-          buildSourceFromExternalLink(
-            "ToMMo",
-            firstExternalLink(externalLinks, "tommo"),
-            "tommo",
-          ),
-          buildSourceFromExternalLink(
-            "JoGo",
-            firstExternalLink(externalLinks, "jogo"),
-            "jogo",
-          ),
-          buildSourceFromExternalLink(
-            "gnomAD",
-            firstExternalLink(externalLinks, "gnomad"),
-            "gnomad",
-          ),
-        ],
+        sources: frequencySources,
       },
     ],
     [
@@ -416,6 +422,7 @@ export default class VariantLinks extends Stanza {
         variantData,
         mogplusEntry,
         mogplusVersion,
+        sourceAssembly,
       );
     } catch (reason) {
       console.error(reason);

--- a/stanzas/variant-links/metadata.json
+++ b/stanzas/variant-links/metadata.json
@@ -32,7 +32,7 @@
     {
       "stanza:key": "assembly",
       "stanza:example": "GRCh38",
-      "stanza:description": "Assembly of the TogoVar variant coordinates. MoG+ lookup is enabled only for GRCh38.",
+      "stanza:description": "Assembly of the TogoVar variant coordinates. MoG+ lookup is enabled only for GRCh38, and JoGo links are hidden for GRCh37.",
       "stanza:required": false
     },
     {


### PR DESCRIPTION
## 概要
`variant-links` stanza の Frequency 欄で、GRCh37 の場合は JoGo リンクを表示しないようにしました。

## 変更内容

- `assembly` パラメータ、または `data-url` / `sparqlist` URL から assembly を判定
- `assembly` が `GRCh37` と判定できる場合、Frequency 欄の JoGo を非表示
- `GRCh38` または assembly 不明の場合は、従来通り JoGo を表示
- `metadata.json` と README に JoGo の表示条件を追記