### PR TITLE
fix variant-links

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -51,7 +51,6 @@ export interface ExternalLinks {
   dbsnp?: ExternalLink[];
   gnomad?: ExternalLink[];
   tommo?: ExternalLink[];
-  tommo_jsv1?: ExternalLink[];
   jogo?: ExternalLink[];
   sscv_db?: ExternalLink[];
 }

--- a/stanzas/variant-links/index.ts
+++ b/stanzas/variant-links/index.ts
@@ -70,7 +70,6 @@ type ExternalLinkKey =
   | "dbsnp"
   | "gnomad"
   | "tommo"
-  | "tommo_jsv1"
   | "jogo"
   | "sscv_db";
 
@@ -300,15 +299,6 @@ const buildLinkCategoryRows = (
       firstExternalLink(externalLinks, "tommo"),
       "tommo",
     ),
-    ...(sourceAssembly === "GRCh38"
-      ? [
-          buildSourceFromExternalLink(
-            "ToMMo JSV1",
-            firstExternalLink(externalLinks, "tommo_jsv1"),
-            "tommo_jsv1",
-          ),
-        ]
-      : []),
   ];
   const frequencySources = [
     buildSourceFromExternalLink(


### PR DESCRIPTION
variant-links の外部リンク一覧(Frequencyカテゴリ)から ToMMo JSV1 エントリを削除。
※ `lib/constants.ts` の `DATASETS` 定義および `variant-frequency` stanza が参照する `tommo_jsv1`(頻度データセットとしてのToMMo JSV1)はスコープ外で、残しています。