### PR TITLE
feat: add external-link component and transcript link logic

### DIFF
--- a/assets/css/common.scss
+++ b/assets/css/common.scss
@@ -5,6 +5,7 @@
 @use "components/clinical-significance";
 @use "components/dataset-icon";
 @use "components/dataTable_wrapper";
+@use "components/external-link";
 @use "components/frequency";
 @use "components/table";
 @use "components/variant-function";

--- a/assets/css/components/_external-link.scss
+++ b/assets/css/components/_external-link.scss
@@ -11,6 +11,7 @@
   }
 }
 
-a:hover > .external-link-icon {
+a:hover > .external-link-icon,
+a:focus-visible > .external-link-icon {
   color: var(--color-key);
 }

--- a/assets/css/components/_external-link.scss
+++ b/assets/css/components/_external-link.scss
@@ -1,0 +1,16 @@
+// 外部リンク(別タブで開くリンク)に添える矢印アイコン。
+.external-link-icon {
+  display: inline-block;
+  margin-left: 3px;
+  font-family: "Font Awesome 7 Free";
+  font-size: 10px;
+  color: var(--color-gray-light);
+
+  &::before {
+    content: var(--icon-arrow-up-right-from-square);
+  }
+}
+
+a:hover > .external-link-icon {
+  color: var(--color-key);
+}

--- a/assets/css/foundation/_variables.scss
+++ b/assets/css/foundation/_variables.scss
@@ -3,6 +3,7 @@
 
 :host {
   // stanza固有、TogoVarフロント側の変数一覧には対応するトークンなし(focusのoutline用)
+  --color-key: #62d5d9;
   --color-key-light: #{color.adjust(#62d5d9, $lightness: 15%)};
   --color-key-dark1: #117f93;
   --color-key-dark2: #0f6272;
@@ -10,6 +11,7 @@
   // color: base
   --color-black: #444;
   --color-gray: #94928d;
+  --color-gray-light: #{color.adjust(#94928d, $lightness: 10%)};
 
   // color: selection / states
   --color-singleton: #{color.adjust(#fd0, $lightness: 35%)};

--- a/assets/css/foundation/_variables.scss
+++ b/assets/css/foundation/_variables.scss
@@ -2,7 +2,7 @@
 @use "sass:color";
 
 :host {
-  // stanza固有、TogoVarフロント側の変数一覧には対応するトークンなし(focusのoutline用)
+  // stanza固有、TogoVarフロント側の変数一覧には対応するトークンなし(focus outlineや外部リンクアイコンのhover色などに使用)
   --color-key: #62d5d9;
   --color-key-light: #{color.adjust(#62d5d9, $lightness: 15%)};
   --color-key-dark1: #117f93;

--- a/stanzas/variant-links/style.scss
+++ b/stanzas/variant-links/style.scss
@@ -113,17 +113,6 @@ main {
         }
       }
 
-      .external-link-icon {
-        display: inline-block;
-        margin-left: 3px;
-        font-family: "Font Awesome 7 Free";
-        font-size: 10px;
-
-        &::before {
-          content: var(--icon-arrow-up-right-from-square);
-        }
-      }
-
       .not-available {
         color: var(--color-gray);
       }

--- a/stanzas/variant-transcript/index.ts
+++ b/stanzas/variant-transcript/index.ts
@@ -18,9 +18,15 @@ import type {
  * URI形式・カンマ区切り文字列・数値スコアが混在しており、表示前に個別変換が必要。
  */
 interface TranscriptSparqlBinding {
-  /** EnsemblトランスクリプトのURI（末尾パスセグメントがIDになる） */
+  /**
+   * トランスクリプトを識別するURI（末尾パスセグメントが表示用IDになる）。
+   * リンクURLとしては使わない（stanza側で enst_id を基に組み立てる）。
+   */
   transcript?: string;
-  /** EnsemblトランスクリプトID。リンクURL生成に使う。transcript URIとは別フィールド。 */
+  /**
+   * Ensembl transcript ID("ENST...")。Ensembl transcriptに紐づく行でのみ束縛される。
+   * それ以外の行（RefSeq側のみに紐づくconsequenceなど）では未束縛になる。
+   */
   enst_id?: string;
   /** VEP由来の MANE 情報。例: "MANE_Select" または ["MANE_Select"] */
   mane?: string | string[];
@@ -42,7 +48,7 @@ interface TranscriptSparqlBinding {
 interface EnsemblTranscriptLink {
   /** URIから取り出したIDラベル文字列 */
   label: string;
-  /** enst_id がない場合はリンクなし（null） */
+  /** transcript/enst_id がどちらも無い場合はリンクなし（null） */
   url: string | null;
 }
 
@@ -102,26 +108,46 @@ interface VariantTranscriptParams extends SparqlistStanzaParams {
 const ENSEMBL_IDENTIFIER_BASE_URL = "http://identifiers.org/ensembl/";
 const MANE_URL = "https://www.ncbi.nlm.nih.gov/refseq/MANE/";
 
+/**
+ * NCBI Nucleotide(Nuccore) の URI プレフィックス。
+ * RefSeq transcript ID(NM_...)と連結してリンクURLを生成する。
+ * identifiers.org の `refseq` 名前空間は NM_... を誤って protein DB へ解決するため使わない。
+ */
+const NCBI_NUCCORE_BASE_URL = "https://www.ncbi.nlm.nih.gov/nuccore/";
+
+/** `enst_id` がEnsembl transcript ID(ENST...)かどうかの判定に使う。 */
+const ENSEMBL_TRANSCRIPT_ID_PATTERN = /^ENST\d/i;
+
 // ============================================================
 // データ変換（バインディング → 表示行）
 // ============================================================
 
 /**
  * URI形式の transcript フィールドと enst_id から、テンプレートが使えるリンク情報を組み立てる。
- * URI の末尾パスセグメントをラベルとして使い、enst_id がない場合は url を null にする。
+ * ラベルは transcript の末尾パスセグメントから取り出す。
+ * sparqlist側はリンクを返さない方針のため、リンクURLは常にstanza側で組み立てる。
+ *
+ * - enst_id がEnsembl transcript ID(ENST...)の場合: identifiers.org 経由でEnsembl公式ページへ。
+ * - それ以外（NM_...など。sparqlist側でtranscriptにEnsembl transcriptが無い行では
+ *   enst_id自体が未束縛になるため、ラベルから取り出したIDを使う）: NCBI Nuccoreへ直接リンクする。
  */
 const createEnsemblTranscriptLink = (
   binding: TranscriptSparqlBinding,
 ): EnsemblTranscriptLink => {
-  // "http://identifiers.org/ensembl/ENST00000123456" → "ENST00000123456"
+  // 例: "http://rdf.ebi.ac.uk/resource/ensembl.transcript/ENST00000123456" → "ENST00000123456"
+  //     "https://www.ncbi.nlm.nih.gov/nuccore/NM_000690.4" → "NM_000690.4"
   const label = binding.transcript
     ? binding.transcript.split("/").pop() || ""
     : "";
 
-  // enst_id が欠落しているバインディングではリンクを表示しない
-  const url = binding.enst_id
+  const isEnsemblTranscriptId = ENSEMBL_TRANSCRIPT_ID_PATTERN.test(
+    binding.enst_id ?? "",
+  );
+  const url = isEnsemblTranscriptId
     ? `${ENSEMBL_IDENTIFIER_BASE_URL}${binding.enst_id}`
-    : null;
+    : label
+      ? `${NCBI_NUCCORE_BASE_URL}${label}`
+      : null;
 
   return { label, url };
 };

--- a/stanzas/variant-transcript/index.ts
+++ b/stanzas/variant-transcript/index.ts
@@ -45,7 +45,7 @@ interface TranscriptSparqlBinding {
 }
 
 /** テンプレートが直接描画できるトランスクリプトのリンク情報。 */
-interface EnsemblTranscriptLink {
+interface TranscriptLink {
   /** enst_id または transcript から取り出したID文字列（表示ラベルを兼ねる） */
   label: string;
   /** transcript/enst_id がどちらも無い場合はリンクなし（null） */
@@ -68,7 +68,7 @@ interface TranscriptDisplayRow
     | "polyphen"
   > {
   /** URIではなくラベルとリンクURLに変換済み */
-  transcript: EnsemblTranscriptLink;
+  transcript: TranscriptLink;
   /** MANE Select transcript の場合にバッジを表示する */
   is_mane_select: boolean;
   mane_url: string;
@@ -135,9 +135,9 @@ const ENSEMBL_TRANSCRIPT_ID_PATTERN = /^ENST\d/i;
  * - IDがEnsembl transcript ID(ENST...)の場合: identifiers.org 経由でEnsembl公式ページへ。
  * - それ以外（NM_...など）: NCBI Nuccoreへ直接リンクする。
  */
-const createEnsemblTranscriptLink = (
+const createTranscriptLink = (
   binding: TranscriptSparqlBinding,
-): EnsemblTranscriptLink => {
+): TranscriptLink => {
   // 例: "http://rdf.ebi.ac.uk/resource/ensembl.transcript/ENST00000123456" → "ENST00000123456"
   //     "https://www.ncbi.nlm.nih.gov/nuccore/NM_000690.4" → "NM_000690.4"
   const transcriptLabel = binding.transcript
@@ -190,7 +190,7 @@ const isManeSelectTranscript = (
  * SPARQL バインディング1行をテンプレート表示行へ変換する。
  *
  * 変換内容:
- * - transcript URI → EnsemblTranscriptLink（ラベル + URL）
+ * - transcript URI → TranscriptLink（ラベル + URL）
  * - consequence_label カンマ区切り文字列 → string 配列
  * - CADD (PHRED score) / AlphaMissense / SIFT / PolyPhen 生スコア
  *   → 表示文字列 + CSS クラス + ラベル
@@ -213,7 +213,7 @@ const convertBindingToDisplayRow = (
     ...sharedFields
   } = binding;
 
-  const transcript = createEnsemblTranscriptLink(binding);
+  const transcript = createTranscriptLink(binding);
   const displayRow: TranscriptDisplayRow = {
     ...sharedFields,
     transcript,

--- a/stanzas/variant-transcript/index.ts
+++ b/stanzas/variant-transcript/index.ts
@@ -19,8 +19,8 @@ import type {
  */
 interface TranscriptSparqlBinding {
   /**
-   * トランスクリプトを識別するURI（末尾パスセグメントが表示用IDになる）。
-   * リンクURLとしては使わない（stanza側で enst_id を基に組み立てる）。
+   * トランスクリプトを識別するURI（末尾パスセグメントが表示用IDの候補になる）。
+   * enst_id が未束縛の行では、この末尾パスセグメントをIDとして使う。
    */
   transcript?: string;
   /**
@@ -46,7 +46,7 @@ interface TranscriptSparqlBinding {
 
 /** テンプレートが直接描画できるトランスクリプトのリンク情報。 */
 interface EnsemblTranscriptLink {
-  /** URIから取り出したIDラベル文字列 */
+  /** enst_id または transcript から取り出したID文字列（表示ラベルを兼ねる） */
   label: string;
   /** transcript/enst_id がどちらも無い場合はリンクなし（null） */
   url: string | null;
@@ -105,7 +105,7 @@ interface VariantTranscriptParams extends SparqlistStanzaParams {
  * Ensembl Identifiers.org の URI プレフィックス。
  * `enst_id` と連結してトランスクリプトのリンクURLを生成する。
  */
-const ENSEMBL_IDENTIFIER_BASE_URL = "http://identifiers.org/ensembl/";
+const ENSEMBL_IDENTIFIER_BASE_URL = "https://identifiers.org/ensembl/";
 const MANE_URL = "https://www.ncbi.nlm.nih.gov/refseq/MANE/";
 
 /**
@@ -124,32 +124,37 @@ const ENSEMBL_TRANSCRIPT_ID_PATTERN = /^ENST\d/i;
 
 /**
  * URI形式の transcript フィールドと enst_id から、テンプレートが使えるリンク情報を組み立てる。
- * ラベルは transcript の末尾パスセグメントから取り出す。
+ * enst_id と、transcript の末尾パスセグメントは同じトランスクリプトを指す想定だが、
+ * どちらか一方しか束縛されない行があるため、束縛されている方を優先してIDとして採用する
+ * （enst_id を優先。無ければ transcript 由来のラベルを使う）。
+ * ラベルとリンク先の判定は、常にこの単一のIDを基準に行うことで、
+ * 「transcript側だけENST形式なのにNCBIへ誤ってリンクする」「enst_idはあるがラベルが空になる」
+ * といった不整合を防ぐ。
  * sparqlist側はリンクを返さない方針のため、リンクURLは常にstanza側で組み立てる。
  *
- * - enst_id がEnsembl transcript ID(ENST...)の場合: identifiers.org 経由でEnsembl公式ページへ。
- * - それ以外（NM_...など。sparqlist側でtranscriptにEnsembl transcriptが無い行では
- *   enst_id自体が未束縛になるため、ラベルから取り出したIDを使う）: NCBI Nuccoreへ直接リンクする。
+ * - IDがEnsembl transcript ID(ENST...)の場合: identifiers.org 経由でEnsembl公式ページへ。
+ * - それ以外（NM_...など）: NCBI Nuccoreへ直接リンクする。
  */
 const createEnsemblTranscriptLink = (
   binding: TranscriptSparqlBinding,
 ): EnsemblTranscriptLink => {
   // 例: "http://rdf.ebi.ac.uk/resource/ensembl.transcript/ENST00000123456" → "ENST00000123456"
   //     "https://www.ncbi.nlm.nih.gov/nuccore/NM_000690.4" → "NM_000690.4"
-  const label = binding.transcript
+  const transcriptLabel = binding.transcript
     ? binding.transcript.split("/").pop() || ""
     : "";
 
-  const isEnsemblTranscriptId = ENSEMBL_TRANSCRIPT_ID_PATTERN.test(
-    binding.enst_id ?? "",
-  );
-  const url = isEnsemblTranscriptId
-    ? `${ENSEMBL_IDENTIFIER_BASE_URL}${binding.enst_id}`
-    : label
-      ? `${NCBI_NUCCORE_BASE_URL}${label}`
-      : null;
+  const id = binding.enst_id || transcriptLabel;
 
-  return { label, url };
+  if (!id) {
+    return { label: "", url: null };
+  }
+
+  const url = ENSEMBL_TRANSCRIPT_ID_PATTERN.test(id)
+    ? `${ENSEMBL_IDENTIFIER_BASE_URL}${id}`
+    : `${NCBI_NUCCORE_BASE_URL}${id}`;
+
+  return { label: id, url };
 };
 
 const isGrch38 = ({ assembly, sparqlist }: VariantTranscriptParams): boolean =>

--- a/stanzas/variant-transcript/templates/stanza.html.hbs
+++ b/stanzas/variant-transcript/templates/stanza.html.hbs
@@ -25,7 +25,10 @@
                 href="{{transcript.url}}"
                 target="_blank"
                 rel="noopener noreferrer"
-              >{{transcript.label}}<span class="external-link-icon"></span></a>
+              >{{transcript.label}}<span
+                  class="external-link-icon"
+                  aria-hidden="true"
+                ></span></a>
             {{else}}
               {{transcript.label}}
             {{/if}}
@@ -44,7 +47,10 @@
                 href="{{gene_xref}}"
                 target="_blank"
                 rel="noopener noreferrer"
-              >{{gene_symbol}}<span class="external-link-icon"></span></a>
+              >{{gene_symbol}}<span
+                  class="external-link-icon"
+                  aria-hidden="true"
+                ></span></a>
             {{else}}
               {{gene_symbol}}
             {{/if}}

--- a/stanzas/variant-transcript/templates/stanza.html.hbs
+++ b/stanzas/variant-transcript/templates/stanza.html.hbs
@@ -21,7 +21,11 @@
         <tr>
           <td>
             {{#if transcript.url}}
-              <a href="{{transcript.url}}">{{transcript.label}}</a>
+              <a
+                href="{{transcript.url}}"
+                target="_blank"
+                rel="noopener noreferrer"
+              >{{transcript.label}}<span class="external-link-icon"></span></a>
             {{else}}
               {{transcript.label}}
             {{/if}}
@@ -34,7 +38,17 @@
               >MANE</a>
             {{/if}}
           </td>
-          <td><a href="{{gene_xref}}">{{gene_symbol}}</a></td>
+          <td>
+            {{#if gene_xref}}
+              <a
+                href="{{gene_xref}}"
+                target="_blank"
+                rel="noopener noreferrer"
+              >{{gene_symbol}}<span class="external-link-icon"></span></a>
+            {{else}}
+              {{gene_symbol}}
+            {{/if}}
+          </td>
           <td>
             <ul class="no-bullet">
               {{#each consequence_label}}


### PR DESCRIPTION
## 概要

- `variant-transcript` のトランスクリプトリンクを、sparqlist側で組み立てず stanza 側で生成するように変更
  - `enst_id` が Ensembl transcript ID(`ENST...`)の場合は identifiers.org 経由で Ensembl 公式ページへ
  - それ以外(RefSeq のみに紐づく行など、`enst_id` が未束縛)の場合は `transcript` のラベルを使って NCBI Nuccore へ直接リンク
- Transcript ID / Gene symbol のリンクを新しいタブで開くようにし(`target="_blank" rel="noopener noreferrer"`)、外部リンクを示す矢印アイコンを追加
- 上記アイコンを `variant-links` から共通コンポーネント(`assets/css/components/_external-link.scss`)に切り出し、`variant-transcript` と共用
  - あわせてアイコンの配色を全stanza共通のグレー→hoverでシアンに統一(`--color-key` / `--color-gray-light` を追加)
- `gene_xref` が未束縛の場合にリンクを出さず gene symbol をテキスト表示するよう修正(transcript 側の既存の分岐と同様のガードを追加)