### PR TITLE
fix: use application/sparql-results+json in sparqlist fetch

### DIFF
--- a/lib/sparqlist.ts
+++ b/lib/sparqlist.ts
@@ -58,11 +58,15 @@ export const describeVariantIdentifier = ({
  * SPARQList エンドポイントから SPARQL バインディングを取得し、
  * `{ value: "..." }` ラッパーを剥がしたプレーンオブジェクト配列として返す。
  * HTTP エラーは Error を throw し、呼び出し元の render() でまとめてハンドリングする。
+ *
+ * Accept は `application/sparql-results+json` を指定する。`application/json` だと
+ * ALTが長い挿入変異など一部のクエリでSPARQList側が空の bindings を返すことがあるため
+ * （レスポンスの形式自体は同じSPARQL結果JSON）、標準のMIMEタイプで明示的にリクエストする。
  */
 export const fetchSparqlBindings = async <T>(apiUrl: string): Promise<T[]> => {
   const response = await fetch(apiUrl, {
     method: "GET",
-    headers: { Accept: "application/json" },
+    headers: { Accept: "application/sparql-results+json" },
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## 概要

ALTが長い挿入変異など一部のクエリで、SPARQListが空の bindings を返し、stanzaに何も表示されない不具合があった。

## 原因

`lib/sparqlist.ts` の `fetchSparqlBindings` が Accept ヘッダーに汎用的な `application/json` を指定していた。SPARQList側はこのヘッダーの場合に限って、一部のクエリ(ALTが長い挿入変異など)で空の bindings を返すことがあった(レスポンスのJSON構造自体は `application/sparql-results+json` の場合と同一)。

## 修正内容

Accept ヘッダーを、SPARQLクエリ結果の標準MIMEタイプである `application/sparql-results+json` に変更し、SPARQList側の意図した処理経路で結果を返すようにした。

この関数は `variant-header` / `variant-clinvar` / `variant-genomic-context` / `variant-transcript` / `variant-summary` の5 stanzaで共通利用されているため、修正はこれら全てに適用される。